### PR TITLE
Improve fallback in case of json schema validation errors

### DIFF
--- a/datadotworld/__init__.py
+++ b/datadotworld/__init__.py
@@ -22,4 +22,4 @@ from __future__ import absolute_import
 
 from datadotworld.datadotworld import load_dataset, query, api_client
 
-__version__ = '1.0.0-beta.1'
+__version__ = '1.0.0-beta.2'


### PR DESCRIPTION
Until https://github.com/frictionlessdata/jsontableschema-py is updated and types like `gyear` and `gyearmonth` are added to the list of supported type, we need to "survive"  schema validation errors.