### PR TITLE
Infer and apply schema from query results

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It will download a given dataset's [datapackage](http://specs.frictionlessdata.i
 and store it under `~/.dw/cache`. When used subsequently, `load_dataset()` will use the copy stored on disk and will
 work offline, unless it's called with `force_update=True`.
 
-Once loaded, a dataset (data and metadata) can be conveniently access via the object returned by `load_dataset()`.
+Once loaded, a dataset (data and metadata) can be conveniently accessed via the object returned by `load_dataset()`.
 
 Start by importing the `datadotworld` module:
 ```python
@@ -45,7 +45,7 @@ intro_dataset = dw.load_dataset('jonloyens/an-intro-to-dataworld-dataset')
 
 Dataset objects allow access to data via three different properties `raw_data`, `tables` and `dataframes`.
 Each of these properties is a mapping (dict) whose values are of type `bytes`, `list` and `pandas.DataFrame`, 
-respectively. Values are lazy loaded and cached once loaded. Their keys are the names of the resources (files) 
+respectively. Values are lazy loaded and cached once loaded. Their keys are the names of the files 
 contained in the dataset.
 
 For example:
@@ -65,36 +65,39 @@ For example:
 ```python
 >>> stats_table = intro_dataset.tables['datadotworldbballstats']
 >>> stats_table[0]
-OrderedDict([('Name', 'Jon'), ('PointsPerGame', Decimal('20.4')), ('AssistsPerGame', Decimal('1.3'))])
+OrderedDict([('Name', 'Jon'),
+             ('PointsPerGame', Decimal('20.4')),
+             ('AssistsPerGame', Decimal('1.3'))])
 ```
 
 You can also review the metadata associated with a file or the entire dataset, using the `describe` function.  
 For example:
 ```python
 >>> intro_dataset.describe()
-{
-    'name': 'jonloyens_an-intro-to-dataworld-dataset', 
-    'homepage': 'https://data.world/jonloyens/an-intro-to-dataworld-dataset', 
-    'resources': [
-        {'path': 'data/ChangeLog.csv', 'name': 'changelog', 'format': 'csv'}, 
-        {'path': 'data/DataDotWorldBBallStats.csv', 'name': 'datadotworldbballstats', 'format': 'csv'}, 
-        {'path': 'data/DataDotWorldBBallTeam.csv', 'name': 'datadotworldbballteam', 'format': 'csv'}
-    ]
-}
+{'homepage': 'https://data.world/jonloyens/an-intro-to-dataworld-dataset',
+ 'name': 'jonloyens_an-intro-to-dataworld-dataset',
+ 'resources': [{'format': 'csv',
+   'name': 'changelog',
+   'path': 'data/ChangeLog.csv'},
+  {'format': 'csv',
+   'name': 'datadotworldbballstats',
+   'path': 'data/DataDotWorldBBallStats.csv'},
+  {'format': 'csv',
+   'name': 'datadotworldbballteam',
+   'path': 'data/DataDotWorldBBallTeam.csv'}]}
+
 
 >>> intro_dataset.describe('datadotworldbballstats')
-{
-    'path': 'data/DataDotWorldBBallStats.csv', 
-    'name': 'datadotworldbballstats', 
-    'format': 'csv', 
-    'schema': {
-        'fields': [
-            {'name': 'Name', 'type': 'string', 'title': 'Name'}, 
-            {'name': 'PointsPerGame', 'type': 'number', 'title': 'PointsPerGame'}, 
-            {'name': 'AssistsPerGame', 'type': 'number', 'title': 'AssistsPerGame'}
-        ]
-    }
-}
+{'format': 'csv',
+ 'name': 'datadotworldbballstats',
+ 'path': 'data/DataDotWorldBBallStats.csv',
+ 'schema': {'fields': [{'name': 'Name', 'title': 'Name', 'type': 'string'},
+                       {'name': 'PointsPerGame',
+                        'title': 'PointsPerGame',
+                        'type': 'number'},
+                       {'name': 'AssistsPerGame',
+                        'title': 'AssistsPerGame',
+                        'type': 'number'}]}}
 ```
 
 ### Query a dataset
@@ -107,7 +110,7 @@ For example:
 results = dw.query('jonloyens/an-intro-to-dataworld-dataset', 'SELECT * FROM DataDotWorldBBallStats')
 ```
 
-Query result objects allow access to the data via `raw_data`, `table` and `dataframe` properties, of type `str`, `list`
+Query result objects allow access to the data via `raw_data`, `table` and `dataframe` properties, of type `json`, `list`
 and `pandas.DataFrame`, respectively.
 
 For example:
@@ -128,11 +131,22 @@ Tables are lists of rows, each represented by a mapping (dict) of column names t
 For example:
 ```python
 >>> results.table[0]
-OrderedDict([('Name', 'Jon'), ('PointsPerGame', '20.4'), ('AssistsPerGame', '1.3')])
+OrderedDict([('Name', 'Jon'),
+             ('PointsPerGame', Decimal('20.4')),
+             ('AssistsPerGame', Decimal('1.3'))])
 ```
 
 To query using `SPARQL` invoke `query()` using `query_type='sparql'`, or else, it will assume 
 the query to be a `SQL` query.
+
+Just like in the dataset case, you can view the metadata associated with a query result using the `describe()` function.
+For example:
+```python
+>>> results.describe()
+{'fields': [{'name': 'Name', 'type': 'string'},
+            {'name': 'PointsPerGame', 'type': 'number'},
+            {'name': 'AssistsPerGame', 'type': 'number'}]}
+```
 
 ### Create and update datasets
 

--- a/datadotworld/__init__.py
+++ b/datadotworld/__init__.py
@@ -22,4 +22,4 @@ from __future__ import absolute_import
 
 from datadotworld.datadotworld import load_dataset, query, api_client
 
-__version__ = '1.0.0-beta.4'
+__version__ = '1.0.0-beta.5'

--- a/datadotworld/config.py
+++ b/datadotworld/config.py
@@ -113,5 +113,6 @@ class Config(object):
             config_parser['default'] = {'auth_token': token}
             config_parser.write(target)
 
-        os.remove(legacy_file_path)
+        # Will leave legacy in case R SDK may still need it
+        # os.remove(legacy_file_path)
         return config_parser

--- a/datadotworld/datadotworld.py
+++ b/datadotworld/datadotworld.py
@@ -92,13 +92,14 @@ class DataDotWorld(object):
                                              query_type, owner_id, dataset_id)
         headers = {
             'User-Agent': _user_agent(),
-            'Accept': 'text/csv',
+            'Accept': 'application/sparql-results+json',
             'Authorization': 'Bearer {0}'.format(self._config.auth_token)
         }
         response = requests.get(url, params=params, headers=headers)
         if response.status_code == 200:
-            return QueryResults(response.text)
-        raise RuntimeError('Error executing query: {}'.format(response.text))
+            return QueryResults(response.json())
+        raise RuntimeError(
+            'Error executing query: {}'.format(response.content))
 
     def load_dataset(self, dataset_key, force_update=False):
         """

--- a/datadotworld/models/dataset.py
+++ b/datadotworld/models/dataset.py
@@ -25,7 +25,7 @@ from collections import OrderedDict
 
 import datapackage
 import six
-from datadotworld.models.util import (sanitize_table_schema,
+from datadotworld.models.util import (sanitize_resource_schema,
                                       align_table_fields,
                                       patch_jsontableschema_pandas)
 from datadotworld.util import LazyLoadedDict, memoized
@@ -73,7 +73,7 @@ class LocalDataset(object):
         # Index resources by name
         self.__resources = {r.descriptor['name']: r
                             for r in self._datapackage.resources}
-        self.__tabular_resources = {k: sanitize_table_schema(r)
+        self.__tabular_resources = {k: sanitize_resource_schema(r)
                                     for (k, r) in self.__resources.items()
                                     if type(r) is TabularResource}
         self.__invalid_schemas = []  # Resource names with invalid schemas

--- a/datadotworld/models/query.py
+++ b/datadotworld/models/query.py
@@ -22,8 +22,55 @@ from __future__ import absolute_import
 
 from collections import OrderedDict
 
-import six
-from tabulator import Stream
+from jsontableschema import Schema
+
+from datadotworld.models.util import sanitize_schema
+
+#: Mapping of Table Schema field types to all suitable RDF literal types
+_TABLE_SCHEMA_TYPE_MAPPINGS = {
+    'bool': [
+        'http://www.w3.org/2001/XMLSchema#boolean'
+    ],
+    'integer': [
+        'http://www.w3.org/2001/XMLSchema#integer',
+        'http://www.w3.org/2001/XMLSchema#nonPositiveInteger',
+        'http://www.w3.org/2001/XMLSchema#nonNegativeInteger',
+        'http://www.w3.org/2001/XMLSchema#negativeInteger',
+        'http://www.w3.org/2001/XMLSchema#long',
+        'http://www.w3.org/2001/XMLSchema#int',
+        'http://www.w3.org/2001/XMLSchema#short',
+        'http://www.w3.org/2001/XMLSchema#byte',
+        'http://www.w3.org/2001/XMLSchema#unsignedLong',
+        'http://www.w3.org/2001/XMLSchema#unsignedInt',
+        'http://www.w3.org/2001/XMLSchema#unsignedShort',
+        'http://www.w3.org/2001/XMLSchema#unsignedByte',
+        'http://www.w3.org/2001/XMLSchema#positiveInteger'
+    ],
+    'number': [
+        'http://www.w3.org/2001/XMLSchema#decimal',
+        'http://www.w3.org/2001/XMLSchema#float',
+        'http://www.w3.org/2001/XMLSchema#double'
+    ],
+    'date': ['http://www.w3.org/2001/XMLSchema#date'],
+    'datetime': [
+        'http://www.w3.org/2001/XMLSchema#dateTime',
+        'http://www.w3.org/2001/XMLSchema#dateTimeStamp'
+    ],
+    'time': ['http://www.w3.org/2001/XMLSchema#time'],
+    'duration': [
+        'http://www.w3.org/2001/XMLSchema#duration',
+        'http://www.w3.org/2001/XMLSchema#dayTimeDuration',
+        'http://www.w3.org/2001/XMLSchema#yearMonthDuration'
+    ],
+    'year': ['http://www.w3.org/2001/XMLSchema#gYear'],
+    'yearmonth': ['http://www.w3.org/2001/XMLSchema#gYearMonth']
+}
+
+#: Mapping of RDF literal types to a single suitable Table Schema field type
+_RDF_LITERAL_TYPE_MAPPING = {xsd_type: ts_type
+                             for ts_type, xsd_types
+                             in _TABLE_SCHEMA_TYPE_MAPPINGS.items()
+                             for xsd_type in xsd_types}
 
 
 class QueryResults(object):
@@ -34,7 +81,7 @@ class QueryResults(object):
     Attributes
     ----------
     raw_data : str
-        Query results as raw CSV data.
+        Query results as raw SPARQL JSON data
     table : list of rows
         Query results as a `list` of rows.
         Each row is a mapping of field names to their respective values.
@@ -45,26 +92,146 @@ class QueryResults(object):
     def __init__(self, raw):
         self.raw_data = raw
 
+        inferred_schema = self._infer_schema_from_results(raw)
+        sanitize_schema(inferred_schema)
+        self._schema = inferred_schema
+
+        self._table = None
+        self._storage = None
+
     def __repr__(self):
         return '{}({})'.format(self.__class__.__name__, repr(self.raw_data))
 
     def __str__(self):
-        return self.raw_data
+        return str(self.raw_data)
+
+    def describe(self):
+        return self._schema
 
     @property
     def dataframe(self):
         try:
-            import pandas as pd
+            from jsontableschema_pandas import Storage
         except ImportError:
             raise RuntimeError('To enable dataframe support, '
-                               'please install the pandas package first.')
-        return pd.DataFrame.from_csv(
-            six.StringIO(self.raw_data), index_col=False)
+                               'run \'pip install datadotworld[PANDAS]\'')
+
+        if self._storage is None:
+            self._storage = Storage()
+            self._storage.create('results', self._schema)
+
+            row_values = [row.values() for row in self.table]
+            self._storage.write('results', row_values)
+
+        return self._storage['results']
 
     @property
     def table(self):
-        # TODO Return typed values based on data.world type inference
-        with Stream(self.raw_data, headers=1,
-                    format='csv', scheme='text') as stream:
-            return [OrderedDict(zip(stream.headers, row))
-                    for row in stream.iter()]
+        if self._table is None:
+            schema_obj = Schema(self._schema)
+            field_names = [field.name for field in schema_obj.fields]
+            result_vars = self.raw_data['head']['vars']
+
+            table = []
+            for binding in self.raw_data['results']['bindings']:
+                values = [rdf_term['value']
+                          for rdf_term in
+                          self._unwrap_binding(result_vars, binding)]
+                table_row = schema_obj.cast_row(values)
+                table.append(OrderedDict(zip(field_names, table_row)))
+
+            self._table = table
+
+        return self._table
+
+    def _infer_schema_from_results(self, sparql_results_json):
+        """Infer Table Schema from SPARQL results JSON
+
+        SPARQL JSON Results Spec:
+        https://www.w3.org/TR/2013/REC-sparql11-results-json-20130321
+
+        Parameters
+        ----------
+        sparql_results_json
+            SPARQL JSON results of a query
+
+        Returns
+        -------
+        dict (json)
+            A schema descriptor for the inferred schema
+        """
+        if ('results' in sparql_results_json and
+                    'bindings' in sparql_results_json['results'] and
+                    len(sparql_results_json['results']['bindings']) > 0):
+
+            result_metadata = sparql_results_json['metadata']
+            result_vars = sparql_results_json['head']['vars']
+            first_binding = sparql_results_json['results']['bindings'][0]
+
+            fields = []
+            unique_field_names = set()
+            for index, rdf_term in enumerate(
+                    self._unwrap_binding(result_vars, first_binding)):
+
+                # Ensures unique field names
+                field_name = result_metadata[index]['name']
+                if field_name in unique_field_names:
+                    field_name += str(index)
+                unique_field_names.add(field_name)
+
+                field = {
+                    'name': field_name,
+                    'type': self._infer_table_schema_type_from_rdf_term(
+                        rdf_term)
+                }
+
+                if 'description' in result_metadata[index]:
+                    field['description'] = result_metadata[index][
+                        'description']
+
+                fields.append(field)
+
+            return {'fields': fields}
+        else:
+            raise ValueError(
+                'Unable to infer table schema from empty query results')
+
+    @staticmethod
+    def _infer_table_schema_type_from_rdf_term(rdf_term):
+        """Map an RDF literal type to Table Schema field type
+
+        Parameters
+        ----------
+        rdf_term
+            A value of an item in a binding. A binding is an item in the
+            bindings section of the SPARQL results JSON.
+
+        Returns
+        -------
+        str
+            A Table Schema field type
+        """
+        if (rdf_term['type'] == 'literal' and
+                    rdf_term.get('datatype') is not None):
+            return _RDF_LITERAL_TYPE_MAPPING.get(rdf_term['datatype'],
+                                                 'string')
+        else:
+            return 'string'
+
+    @staticmethod
+    def _unwrap_binding(result_vars, binding):
+        """Convert a binding into a list ordered in accordance with result_vars
+
+        Parameters
+        ----------
+        result_vars
+            Vars list from SPARQL JSON results
+        binding
+            Item in bindings section of SPARQL results JSON
+
+        Returns
+        -------
+        list
+            A list of RDF terms
+        """
+        return [binding[result_var] for result_var in result_vars]

--- a/datadotworld/models/util.py
+++ b/datadotworld/models/util.py
@@ -1,6 +1,8 @@
 from collections import OrderedDict
 
 
+# Datapackage
+
 def patch_jsontableschema_pandas(mappers):
     """Monkey patch jsontableschema_pandas module
 
@@ -34,41 +36,50 @@ def patch_jsontableschema_pandas(mappers):
         mappers.jtstype_to_dtype = mapper_wrapper
 
 
-def sanitize_table_schema(r):
-    """Sanitize table schema for increased compatibility
-
-    Up to version 0.9.0 jsontableschema did not support
-    year, yearmonth and duration field types
-    https://github.com/frictionlessdata/jsontableschema-py/pull/152
-    """
+def sanitize_schema(schema_descriptor):
     missing_type_support = False
     try:
         from jsontableschema import YearType, YearMonthType, DurationType
     except ImportError:
         missing_type_support = True
 
+    for field in schema_descriptor.get('fields', []):
+        if missing_type_support:
+            # Convert unsupported types to integer and string
+            # as appropriate
+
+            type_mapping = {
+                'integer': [
+                    'gyear', 'year', 'gyearmonth', 'yearmonth'],
+                'string': [
+                    'duration'
+                ]}
+
+            for old_type, new_types in type_mapping.items():
+                if field.get('type') in new_types:
+                    field['type'] = old_type
+
+        # Datapackage specs were changed along the way
+        # Convert gyear and gyearmonth to year and yearmonth
+        # https://github.com/frictionlessdata/specs/pull/370
+        if field.get('type') in ['gyear', 'gyearmonth']:
+            field['type'] = field['type'][1:]
+
+        # Default datetime field format must match '%Y-%m-%dT%H:%M:%SZ'
+        # However, data.world may fail to include 'Z' at the end
+        if field['type'] == 'datetime' and 'format' not in field:
+            field['format'] = 'any'
+
+
+def sanitize_resource_schema(r):
+    """Sanitize table schema for increased compatibility
+
+    Up to version 0.9.0 jsontableschema did not support
+    year, yearmonth and duration field types
+    https://github.com/frictionlessdata/jsontableschema-py/pull/152
+    """
     if 'schema' in r.descriptor:
-        for field in r.descriptor['schema'].get('fields', []):
-            if missing_type_support:
-                # Convert unsupported types to integer and string
-                # as appropriate
-
-                type_mapping = {
-                    'integer': [
-                        'gyear', 'year', 'gyearmonth', 'yearmonth'],
-                    'string': [
-                        'duration'
-                    ]}
-
-                for old_type, new_types in type_mapping.items():
-                    if field.get('type') in new_types:
-                        field['type'] = old_type
-
-            # Datapackage specs were changed along the way
-            # Convert gyear and gyearmonth to year and yearmonth
-            # https://github.com/frictionlessdata/specs/pull/370
-            if field.get('type') in ['gyear', 'gyearmonth']:
-                field['type'] = field['type'][1:]
+        sanitize_schema(r.descriptor['schema'])
 
     return r
 

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
         'click',
         'configparser',
         'datapackage',
+        'jsontableschema>=0.10.0,<1.0a',
         'python-dateutil',
         'requests',
         'six',
@@ -88,12 +89,12 @@ setup(
         'pyhamcrest',
         'responses',
         'pytest',
-        'jsontableschema_pandas',
+        'jsontableschema_pandas>=0.3.0,<1.0a',
         'pandas<0.19a',
     ],
     extras_require={
         'PANDAS': [
-            'jsontableschema_pandas',
+            'jsontableschema_pandas>=0.3.0',
             'pandas<0.19a',
         ],
     },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,23 +1,24 @@
-"""
+'''
 data.world-py
 Copyright 2017 data.world, Inc.
 
-Licensed under the Apache License, Version 2.0 (the "License");
+Licensed under the Apache License, Version 2.0 (the 'License');
 you may not use this file except in compliance with the
 License.
 
 You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
+distributed under the License is distributed on an 'AS IS' BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 implied. See the License for the specific language governing
 permissions and limitations under the License.
 
 This product includes software developed at data.world, Inc.(http://data.world/).
-"""
+'''
 from __future__ import absolute_import
 
+import json
 import os
 from os import path
 
@@ -32,14 +33,16 @@ class Helpers(object):
     @staticmethod
     def validate_request_headers(token='token', user_agent=None):
         from datadotworld import __version__
-        expected_ua_header = user_agent or 'data.world-py - {}'.format(__version__)
+        expected_ua_header = user_agent or 'data.world-py - {}'.format(
+            __version__)
         expected_auth_header = 'Bearer {}'.format(token)
 
         def wrap(f):
             def wrapper(request):
                 headers = request.headers
-                assert_that(headers, has_entries({'Authorization': equal_to(expected_auth_header),
-                                                  'User-Agent': equal_to(expected_ua_header)}))
+                assert_that(headers, has_entries(
+                    {'Authorization': equal_to(expected_auth_header),
+                     'User-Agent': equal_to(expected_ua_header)}))
                 return f(request)
 
             return wrapper
@@ -52,7 +55,9 @@ def helpers():
     return Helpers
 
 
-@pytest.fixture(params=['agentid/datasetid', 'https://data.world/agentid/datasetid'], ids=['simple_key', 'url'])
+@pytest.fixture(
+    params=['agentid/datasetid', 'https://data.world/agentid/datasetid'],
+    ids=['simple_key', 'url'])
 def dataset_key(request):
     return request.param
 
@@ -71,11 +76,13 @@ def config(tmpdir):
 
 
 @pytest.fixture()
-def query_result_csv():
-    return u'cool,beans\n1,2\n3,4\n'
-
-
-@pytest.fixture()
 def test_files_path():
     root_dir = path.dirname(path.abspath(__file__))
     return path.join(root_dir, 'fixtures')
+
+
+@pytest.fixture()
+def query_result_json(test_files_path):
+    with open(path.join(test_files_path, 'sample_query.json'),
+              'r') as json_results:
+        return json.load(json_results)

--- a/tests/datadotworld/models/test_dataset.py
+++ b/tests/datadotworld/models/test_dataset.py
@@ -25,7 +25,7 @@ from os import path
 
 import pytest
 from datadotworld.models.dataset import LocalDataset
-from datadotworld.models.util import sanitize_table_schema
+from datadotworld.models.util import sanitize_resource_schema
 from datapackage import DataPackage, Resource
 from doublex import assert_that, is_
 from hamcrest import equal_to, contains, calling, not_, raises, not_none
@@ -41,7 +41,7 @@ class TestLocalDataset:
     def simpsons_datapackage(self, simpsons_descriptor_path):
         datapackage = DataPackage(descriptor=simpsons_descriptor_path)
         for r in datapackage.resources:
-            sanitize_table_schema(r)
+            sanitize_resource_schema(r)
         return datapackage
 
     @pytest.fixture()

--- a/tests/datadotworld/models/test_query.py
+++ b/tests/datadotworld/models/test_query.py
@@ -21,28 +21,53 @@ data.world, Inc.(http://data.world/).
 from __future__ import absolute_import
 
 import pytest
+from doublex import assert_that
+from hamcrest import equal_to, has_length, contains
 
 from datadotworld.models.query import QueryResults
-from doublex import assert_that
-from hamcrest import equal_to, only_contains
 
 
 class TestQueryResults:
     @pytest.fixture()
-    def query_results(self, query_result_csv):
-        return QueryResults(query_result_csv)
+    def query_results(self, query_result_json):
+        return QueryResults(query_result_json)
 
-    def test_raw_data(self, query_results, query_result_csv):
-        assert_that(query_results.raw_data, equal_to(query_result_csv))
+    @pytest.fixture()
+    def query_result_unique_names(self, query_result_json):
+        unique_names = []
+        for index, name in enumerate(column['name'] for column in
+                                     query_result_json['metadata']):
+            unique_name = (name + str(index)
+                           if name in unique_names else name)
+            unique_names.append(unique_name)
+        return unique_names
 
-    def test_table(self, query_results):
-        expected = ({'cool': '1', 'beans': '2'}, {'cool': '3', 'beans': '4'})
-        assert_that(list(query_results.table), only_contains(*expected))
+    def test_describe(self, query_result_unique_names, query_results):
+        field_names = [f['name'] for f in query_results.describe()['fields']]
+        assert_that(field_names, contains(*query_result_unique_names))
 
-    def test_dataframe(self, query_results):
+    def test_raw_data(self, query_results, query_result_json):
+        assert_that(query_results.raw_data, equal_to(query_result_json))
+
+    def test_table(self, query_result_json, query_result_unique_names,
+                   query_results):
+        for row in query_results.table:
+            assert_that(row.keys(), contains(*query_result_unique_names))
+            assert_that(row.values(),
+                        contains(*(row[f] for f in query_result_unique_names)))
+        assert_that(query_results.table,
+                    has_length(len(query_result_json['results']['bindings'])))
+
+    def test_dataframe(self, query_result_json, query_result_unique_names,
+                       query_results):
         df = query_results.dataframe
-        assert_that(df.shape, equal_to((2, 2)))
-        # TODO More comprehensive assertions
+        assert_that(df['station_id'].dtype, equal_to('int64'))
+        assert_that(df['st.name'].dtype, equal_to('object'))
+        assert_that(df['st.lat'].dtype, equal_to('float64'))
+        assert_that(df['st.datetime'].dtype, equal_to('datetime64[ns]'))
+        assert_that(df.shape,
+                    equal_to((len(query_result_json['results']['bindings']),
+                              len(query_result_unique_names))))
 
-    def test_str(self, query_results, query_result_csv):
-        assert_that(str(query_results), equal_to(query_result_csv))
+    def test_str(self, query_results, query_result_json):
+        assert_that(str(query_results), equal_to(str(query_result_json)))

--- a/tests/datadotworld/test_datadotworld.py
+++ b/tests/datadotworld/test_datadotworld.py
@@ -20,6 +20,7 @@ data.world, Inc.(http://data.world/).
 """
 from __future__ import absolute_import
 
+import json
 import shutil
 from os import path
 
@@ -74,18 +75,18 @@ class TestDataDotWorld:
     @pytest.mark.parametrize("type,endpoint,query", query_types,
                              ids=['sparql', 'sql'])
     def test_query(self, helpers, dw, dataset_key, type, endpoint, query,
-                   query_result_csv):
+                   query_result_json):
         with responses.RequestsMock() as rsps:
             @helpers.validate_request_headers()
             def query_endpoint(_):
-                return 200, {}, query_result_csv
+                return 200, {}, json.dumps(query_result_json)
 
             rsps.add_callback(rsps.GET, '{}?query={}'.format(endpoint, query),
                               content_type='text/csv',
                               callback=query_endpoint, match_querystring=True)
 
             result = dw.query(dataset_key, query, query_type=type)
-            assert_that(result.raw_data, equal_to(query_result_csv))
+            assert_that(result.raw_data, equal_to(query_result_json))
 
     @pytest.mark.parametrize("type,endpoint,query", query_types,
                              ids=['sparql', 'sql'])

--- a/tests/fixtures/sample_query.json
+++ b/tests/fixtures/sample_query.json
@@ -1,0 +1,621 @@
+{
+  "query_text": "SELECT bk.*, st.*\nFROM `bikes.csv/bikes` as bk\nJOIN `stations.csv/stations` as st USING(station_id)\nLIMIT 10\n",
+  "query_lang": "SQL",
+  "metadata": [
+    {
+      "name": "station_id",
+      "type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    {
+      "formatString": "yyyy-MM-dd HH:mm:ss",
+      "name": "bk.datetime",
+      "type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    {
+      "name": "bk.bikes",
+      "type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    {
+      "name": "bk.docks",
+      "type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    {
+      "name": "station_id",
+      "type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    {
+      "name": "st.name",
+      "type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    {
+      "name": "st.address",
+      "type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    {
+      "name": "st.lat",
+      "type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    {
+      "name": "st.lon",
+      "type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    {
+      "formatString": "yyyy-MM-dd HH:mm:ss",
+      "name": "st.datetime",
+      "type": "http://www.w3.org/2001/XMLSchema#string"
+    },
+    {
+      "name": "st.Location",
+      "type": "http://www.w3.org/2001/XMLSchema#string"
+    }
+  ],
+  "head": {
+    "vars": [
+      "v_0",
+      "v_1",
+      "v_2",
+      "v_3",
+      "v_4",
+      "v_5",
+      "v_6",
+      "v_7",
+      "v_8",
+      "v_9",
+      "v_10"
+    ]
+  },
+  "results": {
+    "bindings": [
+      {
+        "v_0": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "1"
+        },
+        "v_1": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+          "value": "2016-04-01T00:00:00"
+        },
+        "v_2": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "6"
+        },
+        "v_3": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "7"
+        },
+        "v_4": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "1"
+        },
+        "v_5": {
+          "type": "literal",
+          "value": "2nd & Congress"
+        },
+        "v_6": {
+          "type": "literal",
+          "value": "151 E. 2nd St, Austin, TX 78701"
+        },
+        "v_7": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#decimal",
+          "value": "30.26408"
+        },
+        "v_8": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#decimal",
+          "value": "-97.74355"
+        },
+        "v_9": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+          "value": "2016-04-01T00:00:00"
+        },
+        "v_10": {
+          "type": "literal",
+          "datatype": "http://www.opengis.net/ont/OGC-GeoSPARQL/1.0/Point",
+          "value": "POINT(30.26408 -97.74355)"
+        }
+      },
+      {
+        "v_0": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "2"
+        },
+        "v_1": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+          "value": "2016-04-01T00:00:00"
+        },
+        "v_2": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "5"
+        },
+        "v_3": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "8"
+        },
+        "v_4": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "2"
+        },
+        "v_5": {
+          "type": "literal",
+          "value": "4th & Congress"
+        },
+        "v_6": {
+          "type": "literal",
+          "value": "120 W. 4th St., Austin, TX 78701"
+        },
+        "v_7": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#decimal",
+          "value": "30.26634"
+        },
+        "v_8": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#decimal",
+          "value": "-97.74378"
+        },
+        "v_9": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+          "value": "2016-04-01T00:00:00"
+        },
+        "v_10": {
+          "type": "literal",
+          "datatype": "http://www.opengis.net/ont/OGC-GeoSPARQL/1.0/Point",
+          "value": "POINT(30.26634 -97.74378)"
+        }
+      },
+      {
+        "v_0": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "11"
+        },
+        "v_1": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+          "value": "2016-04-01T00:00:00"
+        },
+        "v_2": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "1"
+        },
+        "v_3": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "12"
+        },
+        "v_4": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "11"
+        },
+        "v_5": {
+          "type": "literal",
+          "value": "West & 6th St."
+        },
+        "v_6": {
+          "type": "literal",
+          "value": "603 West Ave., Austin, TX 78701"
+        },
+        "v_7": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#decimal",
+          "value": "30.27041"
+        },
+        "v_8": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#decimal",
+          "value": "-97.75046"
+        },
+        "v_9": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+          "value": "2016-04-01T00:00:00"
+        },
+        "v_10": {
+          "type": "literal",
+          "datatype": "http://www.opengis.net/ont/OGC-GeoSPARQL/1.0/Point",
+          "value": "POINT(30.27041 -97.75046)"
+        }
+      },
+      {
+        "v_0": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "5"
+        },
+        "v_1": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+          "value": "2016-04-01T00:10:00"
+        },
+        "v_2": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "8"
+        },
+        "v_3": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "11"
+        },
+        "v_4": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "5"
+        },
+        "v_5": {
+          "type": "literal",
+          "value": "City Hall / Lavaca & 2nd"
+        },
+        "v_6": {
+          "type": "literal",
+          "value": "Presented by Graves Dougherty Hearon & Moody, Austin, TX 78701"
+        },
+        "v_7": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#decimal",
+          "value": "30.26476"
+        },
+        "v_8": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#decimal",
+          "value": "-97.74678"
+        },
+        "v_9": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+          "value": "2016-04-01T00:00:00"
+        },
+        "v_10": {
+          "type": "literal",
+          "datatype": "http://www.opengis.net/ont/OGC-GeoSPARQL/1.0/Point",
+          "value": "POINT(30.26476 -97.74678)"
+        }
+      },
+      {
+        "v_0": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "41"
+        },
+        "v_1": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+          "value": "2016-04-01T01:40:00"
+        },
+        "v_2": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "6"
+        },
+        "v_3": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "7"
+        },
+        "v_4": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "41"
+        },
+        "v_5": {
+          "type": "literal",
+          "value": "Capital Metro HQ - East 5th at Broadway"
+        },
+        "v_6": {
+          "type": "literal",
+          "value": "2910 E 5th St, Austin, TX 78702"
+        },
+        "v_7": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#decimal",
+          "value": "30.2563"
+        },
+        "v_8": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#decimal",
+          "value": "-97.71007"
+        },
+        "v_9": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+          "value": "2016-04-01T00:00:00"
+        },
+        "v_10": {
+          "type": "literal",
+          "datatype": "http://www.opengis.net/ont/OGC-GeoSPARQL/1.0/Point",
+          "value": "POINT(30.2563 -97.71007)"
+        }
+      },
+      {
+        "v_0": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "17"
+        },
+        "v_1": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+          "value": "2016-04-01T17:20:00"
+        },
+        "v_2": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "12"
+        },
+        "v_3": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "1"
+        },
+        "v_4": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "17"
+        },
+        "v_5": {
+          "type": "literal",
+          "value": "East 6th & Pedernales St."
+        },
+        "v_6": {
+          "type": "literal",
+          "value": "2498 E. 6th St., Austin, TX 78702"
+        },
+        "v_7": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#decimal",
+          "value": "30.25895"
+        },
+        "v_8": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#decimal",
+          "value": "-97.71475"
+        },
+        "v_9": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+          "value": "2016-04-01T00:00:00"
+        },
+        "v_10": {
+          "type": "literal",
+          "datatype": "http://www.opengis.net/ont/OGC-GeoSPARQL/1.0/Point",
+          "value": "POINT(30.25895 -97.71475)"
+        }
+      },
+      {
+        "v_0": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "17"
+        },
+        "v_1": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+          "value": "2016-04-08T05:35:00"
+        },
+        "v_2": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "5"
+        },
+        "v_3": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "8"
+        },
+        "v_4": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "17"
+        },
+        "v_5": {
+          "type": "literal",
+          "value": "East 6th & Pedernales St."
+        },
+        "v_6": {
+          "type": "literal",
+          "value": "2498 E. 6th St., Austin, TX 78702"
+        },
+        "v_7": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#decimal",
+          "value": "30.25895"
+        },
+        "v_8": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#decimal",
+          "value": "-97.71475"
+        },
+        "v_9": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+          "value": "2016-04-01T00:00:00"
+        },
+        "v_10": {
+          "type": "literal",
+          "datatype": "http://www.opengis.net/ont/OGC-GeoSPARQL/1.0/Point",
+          "value": "POINT(30.25895 -97.71475)"
+        }
+      },
+      {
+        "v_0": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "18"
+        },
+        "v_1": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+          "value": "2016-04-08T05:35:00"
+        },
+        "v_2": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "6"
+        },
+        "v_3": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "5"
+        },
+        "v_4": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "18"
+        },
+        "v_5": {
+          "type": "literal",
+          "value": "ACC - West & 12th Street"
+        },
+        "v_6": {
+          "type": "literal",
+          "value": "1231 West Ave., Austin, TX 78701"
+        },
+        "v_7": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#decimal",
+          "value": "30.27624"
+        },
+        "v_8": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#decimal",
+          "value": "-97.74831"
+        },
+        "v_9": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+          "value": "2016-04-01T00:00:00"
+        },
+        "v_10": {
+          "type": "literal",
+          "datatype": "http://www.opengis.net/ont/OGC-GeoSPARQL/1.0/Point",
+          "value": "POINT(30.27624 -97.74831)"
+        }
+      },
+      {
+        "v_0": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "19"
+        },
+        "v_1": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+          "value": "2016-04-08T05:35:00"
+        },
+        "v_2": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "9"
+        },
+        "v_3": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "4"
+        },
+        "v_4": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "19"
+        },
+        "v_5": {
+          "type": "literal",
+          "value": "Guadalupe & 21st"
+        },
+        "v_6": {
+          "type": "literal",
+          "value": "2100 Guadalupe St., Austin, TX 78752"
+        },
+        "v_7": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#decimal",
+          "value": "30.28395"
+        },
+        "v_8": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#decimal",
+          "value": "-97.74198"
+        },
+        "v_9": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+          "value": "2016-04-01T00:00:00"
+        },
+        "v_10": {
+          "type": "literal",
+          "datatype": "http://www.opengis.net/ont/OGC-GeoSPARQL/1.0/Point",
+          "value": "POINT(30.28395 -97.74198)"
+        }
+      },
+      {
+        "v_0": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "20"
+        },
+        "v_1": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+          "value": "2016-04-08T05:35:00"
+        },
+        "v_2": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "1"
+        },
+        "v_3": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "12"
+        },
+        "v_4": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+          "value": "20"
+        },
+        "v_5": {
+          "type": "literal",
+          "value": "UT West Mall @ Guadalupe"
+        },
+        "v_6": {
+          "type": "literal",
+          "value": "2242 Guadalupe St., Austin, TX 78705"
+        },
+        "v_7": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#decimal",
+          "value": "30.28576"
+        },
+        "v_8": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#decimal",
+          "value": "-97.74181"
+        },
+        "v_9": {
+          "type": "literal",
+          "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+          "value": "2016-04-01T00:00:00"
+        },
+        "v_10": {
+          "type": "literal",
+          "datatype": "http://www.opengis.net/ont/OGC-GeoSPARQL/1.0/Point",
+          "value": "POINT(30.28576 -97.74181)"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
- Pull query results in application/sparql-results+json format
- Map metadata to Table Schema
- Apply schema to query results (table and dataframe)
- Expose query result schema
- Extra: Keep legacy ~/.data.world post-migration in case it's used by R SDK