### PR TITLE
Add description of conda installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,11 @@ Optionally, you can install the library including pandas support::
 
     pip install datadotworld[pandas]
 
+If you use ``conda`` to manage your python distribution, you can install from the community-maintained [conda-forge](https://conda-forge.github.io/) channel::
+
+    conda install -c conda-forge datadotworld-py
+
+
 Configure
 ---------
 


### PR DESCRIPTION
Hey-lo,

As y'all might be aware of [`conda`](https://conda.io/docs/) is a popular tool in the scientific python community for managing python distributions and environments. While it's compatible with `pip`. It can be nice to install modules directly via `conda` itself. We folks at [conda-forge](https://conda-forge.github.io/), a community-maintained channel of recipes for packages, have just added one for [`datadotworld`](https://anaconda.org/conda-forge/datadotworld-py). This pull adds a note for people who use `conda` about how they can install `datadotworld` directly via our channel.