### PR TITLE
Bryon file read

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -186,7 +186,8 @@ For example:
 Write to a dataset
 ------------------
 
-The ``open_remote_file()`` function allows you to write data to a file in a data.world dataset.
+The ``open_remote_file()`` function allows you to write data to or read data from a file in a
+data.world dataset.
 
 The object that is returned from the ``open_remote_file()`` call is similar to a file handle that
 would be used to write to a local file - it has a ``write()`` method, and contents sent to that
@@ -241,6 +242,31 @@ file in binary mode...
 
         >>> with dw.open_remote_file('username/test-dataset', 'test.txt', mode='wb') as w:
         ...   w.write(bytes([100,97,116,97,46,119,111,114,108,100]))
+
+You can also read data from a file in a similar fashion
+.. code-block:: python
+
+        >>> with dw.open_remote_file('username/test-dataset', 'test.txt', mode='r') as r:
+        ...   print(r.read)
+
+
+Reading from the file into common parsing libraries works naturally, too - when opened in 'r' mode, the
+file object acts as an Iterator of the lines in the file:
+.. code-block:: python
+
+        >>> with dw.open_remote_file('username/test-dataset', 'test.txt', mode='r') as r:
+        ...   csvr = csv.DictReader(r)
+        ...   for row in csvr:
+        ...      print(row['column a'], row['column b'])
+
+
+Reading binary files works naturally, too - when opened in 'rb' mode, ``read()`` returns the contents of
+the file as a byte array, and the file object acts as an iterator of bytes:
+.. code-block:: python
+
+        >>> with dw.open_remote_file('username/test-dataset', 'test', mode='rb') as r:
+        ...   bytes = r.read()
+
 
 API Wrappers
 ------------

--- a/datadotworld/__init__.py
+++ b/datadotworld/__init__.py
@@ -30,7 +30,7 @@ import weakref
 from datadotworld.config import FileConfig, ChainedConfig
 from datadotworld.datadotworld import DataDotWorld
 
-__version__ = '1.3.0'
+__version__ = '1.4.0'
 
 # Convenience top-level functions
 
@@ -139,38 +139,47 @@ def query(dataset_key, query, query_type='sql', profile='default',
 
 
 def open_remote_file(dataset_key, file_name, profile='default',
-                     mode='w'):
+                     mode='w', **kwargs):
     """
-    Open a remote file object that can be used to write to a file in a
-    data.world dataset
+    Open a remote file object that can be used to write to or read from
+    a file in a data.world dataset
 
     Parameters
     ----------
     dataset_key : str
         Dataset identifier, in the form of owner/id
     file_name: str
-        The name of the file to write
-    profile : str, optional
-        Configuration profile (account) to use.
+        The name of the file to open
     mode: str, optional
-        the mode for the file - currently only 'w' (write string) or
-        'wb' (write binary) are supported, any other value will throw
-        an exception
+        the mode for the file - must be 'w', 'wb', 'r', or 'rb' -
+        indicating read/write ('r'/'w') and optionally "binary"
+        handling of the file data.
+    chunk_size: int, optional
+        size of chunked bytes to return when reading streamed bytes
+        in 'rb' mode
+    decode_unicode: bool, optional
+        whether to decode textual responses as unicode when returning
+        streamed lines in 'r' mode
 
     Examples
     --------
     >>> import datadotworld as dw
     >>>
+    >>> # write a text file
     >>> with dw.open_remote_file('username/test-dataset',
     ...                          'test.txt') as w:
     ...   w.write("this is a test.")
     >>>
+    >>> # write a jsonlines file
     >>> import json
     >>> with dw.open_remote_file('username/test-dataset',
     ...                          'test.jsonl') as w:
     ...   json.dump({'foo':42, 'bar':"A"}, w)
+    ...   w.write("\\n")
     ...   json.dump({'foo':13, 'bar':"B"}, w)
+    ...   w.write("\\n")
     >>>
+    >>> # write a csv file
     >>> import csv
     >>> with dw.open_remote_file('username/test-dataset',
     ...                          'test.csv') as w:
@@ -179,18 +188,38 @@ def open_remote_file(dataset_key, file_name, profile='default',
     ...   csvw.writerow({'foo':42, 'bar':"A"})
     ...   csvw.writerow({'foo':13, 'bar':"B"})
     >>>
+    >>> # write a pandas dataframe as a csv file
     >>> import pandas as pd
     >>> df = pd.DataFrame({'foo':[1,2,3,4],'bar':['a','b','c','d']})
     >>> with dw.open_remote_file('username/test-dataset',
     ...                          'dataframe.csv') as w:
     ...   df.to_csv(w, index=False)
     >>>
+    >>> # write a binary file
     >>> with dw.open_remote_file('username/test-dataset',
     >>>                          'test.txt', mode='wb') as w:
     ...   w.write(bytes([100,97,116,97,46,119,111,114,108,100]))
+    >>>
+    >>> # read a text file
+    >>> with dw.open_remote_file('username/test-dataset',
+    ...                          'test.txt', mode='r') as r:
+    ...   print(r.read())
+    >>>
+    >>> # read a csv file
+    >>> with dw.open_remote_file('username/test-dataset',
+    ...                          'test.csv', mode='r') as r:
+    ...   csvr = csv.DictReader(r)
+    ...   for row in csvr:
+    ...      print(row['column a'], row['column b'])
+    >>>
+    >>> # read a binary file
+    >>> with dw.open_remote_file('username/test-dataset',
+    ...                          'test', mode='rb') as r:
+    ...   bytes = r.read()
     """
     return _get_instance(profile).open_remote_file(
-        dataset_key, file_name, mode)
+        dataset_key, file_name,
+        mode=mode, **kwargs)
 
 
 def api_client(profile='default'):

--- a/tests/datadotworld/test_files.py
+++ b/tests/datadotworld/test_files.py
@@ -20,18 +20,19 @@ import csv
 import json
 import responses
 import pytest
+import struct
 from datadotworld.config import DefaultConfig
 from datadotworld.files import RemoteFile, RemoteFileException
 from datadotworld.client.api import RestApiError
 
 
 class TestDataDotWorldFileWriter:
-
-    def test_basic(self):
+    def test_write_basic(self):
         with responses.RequestsMock() as resp:
             def upload_endpoint(request):
                 assert "test" == ''.join([chunk.decode('utf-8') for chunk in request.body])
                 return 200, {}, json.dumps({})
+
             resp.add_callback(resp.PUT,
                               '{}/uploads/{}/{}/files/{}'.format('https://api.data.world/v0',
                                                                  'user', 'dataset', 'file.txt'),
@@ -39,12 +40,13 @@ class TestDataDotWorldFileWriter:
             with RemoteFile(DefaultConfig(), "user/dataset", "file.txt") as writer:
                 writer.write("test")
 
-    def test_csv(self):
+    def test_write_csv(self):
         with responses.RequestsMock() as resp:
             def upload_endpoint(request):
                 assert "a,b\r\n42,17\r\n420,178\r\n" == \
-                    ''.join([chunk.decode('utf-8') for chunk in request.body])
+                       ''.join([chunk.decode('utf-8') for chunk in request.body])
                 return 200, {}, json.dumps({})
+
             resp.add_callback(resp.PUT,
                               '{}/uploads/{}/{}/files/{}'.format('https://api.data.world/v0',
                                                                  'user', 'dataset', 'file.csv'),
@@ -52,11 +54,10 @@ class TestDataDotWorldFileWriter:
             with RemoteFile(DefaultConfig(), "user/dataset", "file.csv") as writer:
                 csvw = csv.DictWriter(writer, fieldnames=['a', 'b'])
                 csvw.writeheader()
-                csvw.writerow({'a': 42, 'b':17})
-                csvw.writerow({'a': 420, 'b':178})
+                csvw.writerow({'a': 42, 'b': 17})
+                csvw.writerow({'a': 420, 'b': 178})
 
-
-    def test_error(self):
+    def test_write_error(self):
         with pytest.raises(RestApiError):
             with responses.RequestsMock() as resp:
                 def upload_endpoint(request):
@@ -69,9 +70,143 @@ class TestDataDotWorldFileWriter:
                 with RemoteFile(DefaultConfig(), "user/dataset", "file.txt") as writer:
                     writer.write("test")
 
-
-    def test_timeout_error(self):
+    def test_write_timeout_error(self):
         with pytest.raises(RemoteFileException):
             with RemoteFile(DefaultConfig(), "user/dataset", "file.txt", timeout=0.0) as writer:
                 writer.write("test")
 
+    def test_read_basic(self):
+        with responses.RequestsMock() as resp:
+            def download_endpoint(request):
+                return 200, {}, "this is the test."
+
+            resp.add_callback(resp.GET,
+                              '{}/file_download/{}/{}/{}'.format('https://query.data.world',
+                                                                 'user', 'dataset', 'file.txt'),
+                              callback=download_endpoint)
+            with RemoteFile(DefaultConfig(), "user/dataset", "file.txt", mode="r") as reader:
+                contents = reader.read()
+                assert "this is the test." == contents
+
+    def test_read_non_utf_8(self):
+        with responses.RequestsMock() as resp:
+            def download_endpoint(request):
+                return 200, {}, "this is the test.".encode('utf-16')
+
+            resp.add_callback(resp.GET,
+                              '{}/file_download/{}/{}/{}'.format('https://query.data.world',
+                                                                 'user', 'dataset', 'file.txt'),
+                              callback=download_endpoint)
+            with RemoteFile(DefaultConfig(), "user/dataset", "file.txt", mode="rb") as reader:
+                contents = reader.read()
+                assert "this is the test." == contents.decode('utf-16')
+
+    def test_read_binary_basic(self):
+        with responses.RequestsMock() as resp:
+            def download_endpoint(request):
+                return 200, {}, "this is the test."
+
+            resp.add_callback(resp.GET,
+                              '{}/file_download/{}/{}/{}'.format('https://query.data.world',
+                                                                 'user', 'dataset', 'file.txt'),
+                              callback=download_endpoint)
+            with RemoteFile(DefaultConfig(), "user/dataset", "file.txt", mode="rb") as reader:
+                contents = reader.read()
+                assert b"this is the test." == contents
+
+    def test_read_binary_bytes(self):
+        with responses.RequestsMock() as resp:
+            def download_endpoint(request):
+                return 200, {}, struct.pack('BBBB', 0, 1, 254, 255)
+
+            resp.add_callback(resp.GET,
+                              '{}/file_download/{}/{}/{}'.format('https://query.data.world',
+                                                                 'user', 'dataset', 'file.txt'),
+                              callback=download_endpoint)
+            with RemoteFile(DefaultConfig(), "user/dataset", "file.txt", mode="rb") as reader:
+                contents = reader.read()
+                assert b"\x00\x01\xfe\xff" == contents
+
+    def test_read_binary_iter(self):
+        with responses.RequestsMock() as resp:
+            def download_endpoint(request):
+                return 200, {}, "abcdef"
+
+            resp.add_callback(resp.GET,
+                              '{}/file_download/{}/{}/{}'.format('https://query.data.world',
+                                                                 'user', 'dataset', 'file.txt'),
+                              callback=download_endpoint)
+            with RemoteFile(DefaultConfig(), "user/dataset", "file.txt", mode="rb") as reader:
+                contents = list(reader)
+                assert [b'a', b'b', b'c', b'd', b'e', b'f'] == contents
+
+    def test_read_binary_iter_chunks(self):
+        with responses.RequestsMock() as resp:
+            def download_endpoint(request):
+                return 200, {}, "abcdef"
+
+            resp.add_callback(resp.GET,
+                              '{}/file_download/{}/{}/{}'.format('https://query.data.world',
+                                                                 'user', 'dataset', 'file.txt'),
+                              callback=download_endpoint)
+            with RemoteFile(DefaultConfig(), "user/dataset", "file.txt",
+                            mode="rb", chunk_size=4) as reader:
+                contents = list(reader)
+                assert [b'abcd', b'ef'] == contents
+
+    def test_read_binary_bytes_iter(self):
+        with responses.RequestsMock() as resp:
+            def download_endpoint(request):
+                return 200, {}, struct.pack('BBBB', 0, 1, 254, 255)
+
+            resp.add_callback(resp.GET,
+                              '{}/file_download/{}/{}/{}'.format('https://query.data.world',
+                                                                 'user', 'dataset', 'file.txt'),
+                              callback=download_endpoint)
+            with RemoteFile(DefaultConfig(), "user/dataset", "file.txt", mode="rb") as reader:
+                contents = list(reader)
+                assert [b"\x00", b"\x01", b"\xfe", b"\xff"] == contents
+
+    def test_read_error(self):
+        with pytest.raises(RestApiError):
+            with responses.RequestsMock() as resp:
+                def download_endpoint(request):
+                    return 400, {}, json.dumps({'message': 'bad request'})
+
+                resp.add_callback(resp.GET,
+                                  '{}/file_download/{}/{}/{}'.format('https://query.data.world',
+                                                                     'user', 'dataset', 'file.txt'),
+                                  callback=download_endpoint)
+                with RemoteFile(DefaultConfig(), "user/dataset", "file.txt", mode="r") as reader:
+                    contents = reader.read()
+                    assert "this is the test." == contents
+
+    def test_read_csv(self):
+        with responses.RequestsMock() as resp:
+            def download_endpoint(request):
+                return 200, {}, "A,B,C\n1,2,3\n4,5,6"
+
+            resp.add_callback(resp.GET,
+                              '{}/file_download/{}/{}/{}'.format('https://query.data.world',
+                                                                 'user', 'dataset', 'file.csv'),
+                              callback=download_endpoint)
+            with RemoteFile(DefaultConfig(), "user/dataset", "file.csv", mode="r") as reader:
+                csvr = csv.DictReader(reader)
+                rows = list(csvr)
+                assert rows[0] == {'A': '1', 'B': '2', 'C': '3'}
+                assert rows[1] == {'A': '4', 'B': '5', 'C': '6'}
+
+    def test_read_jsonl(self):
+        with responses.RequestsMock() as resp:
+            def download_endpoint(request):
+                return 200, {}, '{"A":"1", "B":"2", "C":"3"}\n' \
+                                '{"A":"4", "B":"5", "C":"6"}\n'
+
+            resp.add_callback(resp.GET,
+                              '{}/file_download/{}/{}/{}'.format('https://query.data.world',
+                                                                 'user', 'dataset', 'file.csv'),
+                              callback=download_endpoint)
+            with RemoteFile(DefaultConfig(), "user/dataset", "file.csv", mode="r") as reader:
+                rows = [json.loads(line) for line in reader if line.strip()]
+                assert rows[0] == {'A': '1', 'B': '2', 'C': '3'}
+                assert rows[1] == {'A': '4', 'B': '5', 'C': '6'}


### PR DESCRIPTION
Added "read" mode support for the `open_remote_file` operation.

note that, per python files, the "binary" modifier on this does nothing here - the normal meaning of the 'b' flag for READING files in python has to do with Windoze files, which loses its meaning in the HTTP case.  You have to "decode" binary data as strings in a way that is inconsistent with the write mode, which accepts byte arrays.

I am considering maybe handling the 'b' flag by adding a `read_b` method that reads a fixed number of bytes into a buffer?  for now, leaving it alone - but accepting `rb` as a valid mode.