### PR TITLE
fixed issue where we overwrite delegated values in RestApiError

### DIFF
--- a/datadotworld/client/api.py
+++ b/datadotworld/client/api.py
@@ -473,6 +473,7 @@ class RestApiError(Exception):
 
     def __init__(self, *args, **kwargs):
         self.cause = kwargs.pop('cause', None)
+        self.status, self.reason, self.body = None, None, None
         if self.cause is not None:
             if type(self.cause) is _swagger.rest.ApiException:
                 self.status = self.cause.status
@@ -486,9 +487,9 @@ class RestApiError(Exception):
                     self.body = requests_response.content
                     self.json = requests_response.json  # Delegates to requests
 
-        self.status = kwargs.pop('status', None)
-        self.reason = kwargs.pop('reason', None)
-        self.body = kwargs.pop('body', None)
+        self.status = kwargs.pop('status', self.status)
+        self.reason = kwargs.pop('reason', self.reason)
+        self.body = kwargs.pop('body', self.body)
         super(RestApiError, self).__init__(*args, **kwargs)
 
     def json(self):

--- a/tests/datadotworld/client/test_client.py
+++ b/tests/datadotworld/client/test_client.py
@@ -30,6 +30,7 @@ from hamcrest import (equal_to, has_entries, has_properties, is_, described_as,
                       empty, raises, calling)
 
 from datadotworld.client._swagger import DatasetsApi, UploadsApi
+from datadotworld.client._swagger.rest import ApiException
 from datadotworld.client._swagger.models import *
 from datadotworld.client.api import RestApiClient, RestApiError
 
@@ -119,6 +120,14 @@ class TestApiClient:
                     called().times(1).with_args(equal_to('agentid'),
                                                 equal_to('datasetid'),
                                                 equal_to(files)))
+
+    def test_rest_api_error(self):
+        apix = ApiException(status=400, reason="boom")
+        e = RestApiError(cause=apix)
+        assert_that(e.status, equal_to(400))
+        assert_that(e.reason, equal_to("boom"))
+        assert_that(e.body, equal_to(None))
+        assert_that(e.cause, equal_to(apix))
 
     # TODO Test CRUD exception cases
 


### PR DESCRIPTION
Noted that when we construct RestApiError from an underlying cause, we then immediately overwrote the values - this fixes that.