### PR TITLE
Bryon issue 68

### DIFF
--- a/datadotworld/__init__.py
+++ b/datadotworld/__init__.py
@@ -30,7 +30,7 @@ import weakref
 from datadotworld.config import FileConfig, ChainedConfig
 from datadotworld.datadotworld import DataDotWorld, UriParam
 
-__version__ = '1.4.2'
+__version__ = '1.4.3'
 
 # Convenience top-level functions
 

--- a/tests/datadotworld/models/test_query.py
+++ b/tests/datadotworld/models/test_query.py
@@ -94,5 +94,15 @@ class TestQueryResults:
                     equal_to((len(query_result_example['results']['bindings']),
                               len(metadata_names))))
 
+    def test_str_column(self, query_results):
+        '''
+        Test added for https://github.com/datadotworld/data.world-py/issues/68
+        added a value in the `st.name` column in sql_select.json of "NONE",
+        which was previously mapped to Python `None` - this verifies that we
+        have fixed that issue.
+        '''
+        for value in query_results.dataframe['st.name']:
+            assert_that(value)
+
     def test_str(self, query_results, query_result_example):
         assert_that(str(query_results), equal_to(str(query_result_example)))

--- a/tests/fixtures/queries/sql_select.json
+++ b/tests/fixtures/queries/sql_select.json
@@ -589,7 +589,7 @@
         },
         "v_5": {
           "type": "literal",
-          "value": "UT West Mall @ Guadalupe"
+          "value": "NONE"
         },
         "v_6": {
           "type": "literal",


### PR DESCRIPTION
Post-processing the return value from `jsontableschema`'s value mapping to correct places where that mapping converted string literals into `None`