### PR TITLE
Clearing cache when `LocalDataset` is instantiated

### DIFF
--- a/datadotworld/models/dataset.py
+++ b/datadotworld/models/dataset.py
@@ -78,6 +78,16 @@ class LocalDataset(object):
                                     r.descriptor['path'].startswith('data')}
         self.__invalid_schemas = []  # Resource names with invalid schemas
 
+        self._load_raw_data = memoized(
+            key_mapper=lambda resource_name: resource_name)(
+                self._load_raw_data)
+        self._load_table = memoized(
+            key_mapper=lambda resource_name: resource_name)(
+                self._load_table)
+        self._load_dataframe = memoized(
+            key_mapper=lambda resource_name: resource_name)(
+                self._load_dataframe)
+
         # All formats
         self.raw_data = LazyLoadedDict.from_keys(
             self.__resources.keys(),
@@ -114,7 +124,6 @@ class LocalDataset(object):
         else:
             return self.__resources[resource].descriptor
 
-    @memoized(key_mapper=lambda self, resource_name: resource_name)
     def _load_raw_data(self, resource_name):
         """Extract raw data from resource
 
@@ -127,7 +136,7 @@ class LocalDataset(object):
             default_base_path=self.__base_path)
         return upcast_resource.data
 
-    @memoized(key_mapper=lambda self, resource_name: resource_name)
+    # @memoized(key_mapper=lambda self, resource_name: resource_name)
     def _load_table(self, resource_name):
         """Build table structure from resource data
 
@@ -160,7 +169,6 @@ class LocalDataset(object):
                 return [OrderedDict(zip(stream.headers, row))
                         for row in stream.iter()]
 
-    @memoized(key_mapper=lambda self, resource_name: resource_name)
     def _load_dataframe(self, resource_name):
         """Build pandas.DataFrame from resource data
 

--- a/datadotworld/models/dataset.py
+++ b/datadotworld/models/dataset.py
@@ -99,6 +99,7 @@ class LocalDataset(object):
             self.__tabular_resources.keys(),
             self._load_table,
             type_hint='list of rows')
+
         self.dataframes = LazyLoadedDict.from_keys(
             self.__tabular_resources.keys(),
             self._load_dataframe,
@@ -136,7 +137,6 @@ class LocalDataset(object):
             default_base_path=self.__base_path)
         return upcast_resource.data
 
-    # @memoized(key_mapper=lambda self, resource_name: resource_name)
     def _load_table(self, resource_name):
         """Build table structure from resource data
 

--- a/datadotworld/models/dataset.py
+++ b/datadotworld/models/dataset.py
@@ -24,7 +24,6 @@ import io
 from collections import OrderedDict
 
 import datapackage
-import six
 from datapackage.resource import TabularResource
 from jsontableschema.exceptions import SchemaValidationError
 from os import path

--- a/datadotworld/util.py
+++ b/datadotworld/util.py
@@ -94,7 +94,10 @@ class LazyLoadedDict(Mapping):
             lambda k=k: loader_func(k), type_hint=type_hint) for k in keys})
 
     def __getitem__(self, item):
-        return self._dict[item]()
+        try:
+            return self._dict[item]()
+        except:
+            return self._dict[item]
 
     def __iter__(self):
         return iter(self._dict.keys())

--- a/datadotworld/util.py
+++ b/datadotworld/util.py
@@ -144,19 +144,19 @@ class memoized(object):
             key = self.key_mapper(*args) or args
             obj = args[0]
 
-            if not hasattr(obj, 'cache'):
+            if not hasattr(obj, '__memoized__'):
                 try:
-                    obj.cache = {}
-                    instance_cache = obj.cache
+                    obj.__memoized__ = {}
+                    instance_cache = obj.__memoized__
                 except AttributeError:
-                    if not hasattr(wrapper, 'cache'):
-                        wrapper.cache = {}
-                    instance_cache = wrapper.cache
+                    if not hasattr(wrapper, '__memoized__'):
+                        wrapper.__memoized__ = {}
+                    instance_cache = wrapper.__memoized__
             else:
                 try:
-                    instance_cache = obj.cache
+                    instance_cache = obj.__memoized__
                 except AttributeError:
-                    instance_cache = wrapper.cache
+                    instance_cache = wrapper.__memoized__
 
             instance_cache[id(func)] = instance_cache.get(id(func), {})
 

--- a/datadotworld/util.py
+++ b/datadotworld/util.py
@@ -153,10 +153,6 @@ class memoized(object):
                 # better to not cache than blow up.
                 return func(*args)
 
-            # clear cache if object id does not exist in cache
-            if obj_id not in self.cache:
-                self.cache.clear()
-
             if key not in self.cache.get(obj_id, {}):
                 val = func(*args, **kwargs)
                 self.cache[obj_id] = self.cache.get(obj_id, {})


### PR DESCRIPTION
@rflprr - Thought to run this option by you. I was thinking about the second possible way to resolve the cache issue that we discussed (i.e: moving the cache object to the `LocalDataset` class which in turn I guess will make the use of `@memoize` unnecessary), so I thought how about if we move calling of `memoize` on each function (`_load_raw_data`, `_load_table` and `_load_dataframe`) to `LocalDataset` init, so each time the class is initialized, memoized is call thereby creating a new cache object. So, instead of using the syntactic sugar pie syntax to decorate the function, I called it directly on the function itself. Although this works, somehow the test fails for `test_tables_broken_schema`, not sure why it does.