### PR TITLE
Fixes in preparation for 1.5.0 release

### DIFF
--- a/datadotworld/__init__.py
+++ b/datadotworld/__init__.py
@@ -35,7 +35,7 @@ from datadotworld.config import (
 )
 from datadotworld.datadotworld import DataDotWorld, UriParam  # noqa: F401
 
-__version__ = '1.4.3'
+__version__ = '1.5.0'
 
 # Convenience top-level functions
 

--- a/datadotworld/client/_swagger/models/file_source_create_or_update_request.py
+++ b/datadotworld/client/_swagger/models/file_source_create_or_update_request.py
@@ -78,7 +78,7 @@ class FileSourceCreateOrUpdateRequest(object):
             raise ValueError("Invalid value for `url`, length must be less than or equal to `4096`")
         if url is not None and len(url) < 1:
             raise ValueError("Invalid value for `url`, length must be greater than or equal to `1`")
-        if url is not None and not re.search('^https?.*', url):
+        if url is not None and not re.search('^(https?|stream).*', url):
             raise ValueError("Invalid value for `url`, must be a follow pattern or equal to `/^https?.*/`")
 
         self._url = url

--- a/datadotworld/client/_swagger/models/file_source_summary_response.py
+++ b/datadotworld/client/_swagger/models/file_source_summary_response.py
@@ -97,7 +97,7 @@ class FileSourceSummaryResponse(object):
             raise ValueError("Invalid value for `url`, length must be less than or equal to `4096`")
         if url is not None and len(url) < 1:
             raise ValueError("Invalid value for `url`, length must be greater than or equal to `1`")
-        if url is not None and not re.search('^https?.*', url):
+        if url is not None and not re.search('^(https?|stream).*', url):
             raise ValueError("Invalid value for `url`, must be a follow pattern or equal to `/^https?.*/`")
 
         self._url = url

--- a/datadotworld/client/api.py
+++ b/datadotworld/client/api.py
@@ -198,7 +198,8 @@ class RestApiClient(object):
                     name=name,
                     source=_swagger.FileSourceCreateOrUpdateRequest(
                             url=url,
-                            expand_archive=expand_archive) if url is not None else None,
+                            expand_archive=expand_archive)
+                    if url is not None else None,
                     description=description,
                     labels=labels),
             kwargs)

--- a/datadotworld/client/api.py
+++ b/datadotworld/client/api.py
@@ -29,6 +29,7 @@ from os import path
 import functools
 
 import requests
+import six
 
 from datadotworld.client import _swagger
 from datadotworld.client.content_negotiating_api_client import (
@@ -197,7 +198,7 @@ class RestApiClient(object):
                     name=name,
                     source=_swagger.FileSourceCreateOrUpdateRequest(
                             url=url,
-                            expand_archive=expand_archive),
+                            expand_archive=expand_archive) if url is not None else None,
                     description=description,
                     labels=labels),
             kwargs)
@@ -614,7 +615,7 @@ class RestApiClient(object):
         :type include_table_schema: bool
         :returns: file object that can be used in file parsers and
             data handling modules.
-        :rtype: file object
+        :rtype: file-like object
         :raises RestApiException: If a server error occurs
 
         Examples
@@ -628,7 +629,9 @@ class RestApiClient(object):
         sql_api = kwargs.get('sql_api_mock', _swagger.SqlApi(api_client))
         owner_id, dataset_id = parse_dataset_key(dataset_key)
         try:
-            return sql_api.sql_post(owner_id, dataset_id, query, **kwargs)
+            response = sql_api.sql_post(
+                owner_id, dataset_id, query, _preload_content=False, **kwargs)
+            return six.BytesIO(response.data)
         except _swagger.rest.ApiException as e:
             raise RestApiError(cause=e)
 
@@ -660,8 +663,9 @@ class RestApiClient(object):
                                 _swagger.SparqlApi(api_client))
         owner_id, dataset_id = parse_dataset_key(dataset_key)
         try:
-            return sparql_api.sparql_post(owner_id, dataset_id, query,
-                                          **kwargs)
+            response = sparql_api.sparql_post(
+                owner_id, dataset_id, query, _preload_content=False, **kwargs)
+            return six.BytesIO(response.data)
         except _swagger.rest.ApiException as e:
             raise RestApiError(cause=e)
 

--- a/tests/datadotworld/client/test_client.py
+++ b/tests/datadotworld/client/test_client.py
@@ -26,7 +26,7 @@ import pytest
 import responses
 from doublex import assert_that, Spy, called, Mock
 from hamcrest import (equal_to, has_entries, has_properties, is_, described_as,
-                      empty, raises, calling, has_key, not_none)
+                      empty, raises, calling, has_key)
 
 from datadotworld.client._swagger import (
     DatasetsApi,

--- a/tests/datadotworld/client/test_client.py
+++ b/tests/datadotworld/client/test_client.py
@@ -24,9 +24,9 @@ from os import path
 
 import pytest
 import responses
-from doublex import assert_that, Spy, called
+from doublex import assert_that, Spy, called, Mock
 from hamcrest import (equal_to, has_entries, has_properties, is_, described_as,
-                      empty, raises, calling, has_key)
+                      empty, raises, calling, has_key, not_none)
 
 from datadotworld.client._swagger import (
     DatasetsApi,
@@ -61,7 +61,6 @@ class TestApiClient:
     @pytest.fixture()
     def uploads_api(self):
         with Spy(UploadsApi) as api:
-            api.get_dataset = lambda o, d: DatasetSummaryResponse(o, d)
             return api
 
     @pytest.fixture()
@@ -72,15 +71,23 @@ class TestApiClient:
             return api
 
     @pytest.fixture()
-    def sql_api(self):
+    def query_resp(self):
+        with Mock() as response:
+            response.data = 'result'.encode()
+            return response
+
+    @pytest.fixture()
+    def sql_api(self, query_resp):
         with Spy(SqlApi) as api:
-            api.sql_post
+            api.sql_post = \
+                lambda o, d, q, sql_api_mock, _preload_content: query_resp
             return api
 
     @pytest.fixture()
-    def sparql_api(self):
+    def sparql_api(self, query_resp):
         with Spy(SparqlApi) as api:
-            api.sparql_post
+            api.sparql_post = \
+                lambda o, d, q, sparql_api_mock, _preload_content: query_resp
             return api
 
     @pytest.fixture()
@@ -272,17 +279,13 @@ class TestApiClient:
                                                 'file'))
 
     def test_sql(self, api_client, dataset_key, sql_api):
-        api_client.sql(dataset_key, 'query', sql_api_mock=sql_api)
-        assert_that(sql_api.sql_post,
-                    called().times(1).with_args('agentid', 'datasetid',
-                                                'query', sql_api_mock=sql_api))
+        result = api_client.sql(dataset_key, 'query', sql_api_mock=sql_api)
+        assert_that(result.read().decode('utf-8'), equal_to('result'))
 
     def test_sparql(self, api_client, dataset_key, sparql_api):
-        api_client.sparql(dataset_key, 'query', sparql_api_mock=sparql_api)
-        assert_that(sparql_api.sparql_post,
-                    called().times(1).with_args('agentid', 'datasetid',
-                                                'query',
-                                                sparql_api_mock=sparql_api))
+        result = api_client.sparql(dataset_key, 'query',
+                                   sparql_api_mock=sparql_api)
+        assert_that(result.read().decode('utf-8'), equal_to('result'))
 
     def test_get_user_data(self, api_client):
         user_data_response = api_client.get_user_data()


### PR DESCRIPTION
- Fix `sql()` and `sparql()`
- Relax validation of file source URLs to accommodate streams
- Create file source object in `update_dataset()` only if `url` is provided
- Update version