### PR TITLE
Upgrading tabulator to 1.19.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         'python-dateutil>=2.6.0,<3.0a',
         'requests>=2.0.0,<3.0a',
         'six>=1.5.0,<2.0a',
-        'tabulator<=1.4.1',
+        'tabulator<=1.19.3',
         'urllib3>=1.15,<2.0a',
         'flake8>=2.6.0,<3.4.1a',
     ],


### PR DESCRIPTION
Currently, running `pip install datadotworld` results in:

```
Command "/private/tmp/test/bin/python -u -c "import setuptools, tokenize;__file__='/private/var/folders/w2/dv053zw95hxb8wkmfkc3ybv80000gn/T/pip-install-oz_5t9hy/cchardet/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /private/var/folders/w2/dv053zw95hxb8wkmfkc3ybv80000gn/T/pip-record-vgyir6xa/install-record.txt --single-version-externally-managed --compile --install-headers /private/tmp/test/include/site/python3.7/cchardet" failed with error code 1 in /private/var/folders/w2/dv053zw95hxb8wkmfkc3ybv80000gn/T/pip-install-oz_5t9hy/cchardet/
```

@scottcame found that the version of cchardet required is known to have this failure.

This PR updates the version of Tabulator so as to make use of a more recent version of cchardet.