### PR TITLE
Lazy filesystem operations at FileConfig

### DIFF
--- a/datadotworld/config.py
+++ b/datadotworld/config.py
@@ -104,7 +104,12 @@ class FileConfig(DefaultConfig):
                          if profile.lower() != configparser.DEFAULTSECT.lower()
                          else configparser.DEFAULTSECT)
 
-        self.configure_config_parser()
+    @property
+    def config_parser(self):
+        if self._config_parser is None:
+            self.configure_config_parser()
+
+        return self._config_parser
 
     def configure_config_parser(self):
         if not path.isdir(path.dirname(self._config_file_path)):
@@ -127,7 +132,7 @@ class FileConfig(DefaultConfig):
     @property
     def auth_token(self):
         self.__validate_config()
-        return self._config_parser.get(self._section, 'auth_token')
+        return self.config_parser.get(self._section, 'auth_token')
 
     @auth_token.setter
     def auth_token(self, auth_token):
@@ -137,22 +142,25 @@ class FileConfig(DefaultConfig):
 
         """
         if (self._section != configparser.DEFAULTSECT and
-                not self._config_parser.has_section(self._section)):
-            self._config_parser.add_section(self._section)
-        self._config_parser.set(self._section, 'auth_token', auth_token)
+                not self.config_parser.has_section(self._section)):
+            self.config_parser.add_section(self._section)
+        self.config_parser.set(self._section, 'auth_token', auth_token)
 
     def save(self):
         """Persist config changes"""
         with open(self._config_file_path, 'w') as file:
-            self._config_parser.write(file)
+            self.config_parser.write(file)
 
     def __validate_config(self):
+        config_parser = self.config_parser
+
         if not path.isfile(self._config_file_path):
             raise RuntimeError(
                 'Configuration file not found at {}.'
                 'To fix this issue, run dw configure'.format(
                     self._config_file_path))
-        if not self._config_parser.has_option(self._section, 'auth_token'):
+
+        if not config_parser.has_option(self._section, 'auth_token'):
             raise RuntimeError(
                 'The {0} profile is not properly configured. '
                 'To fix this issue, run dw -p {0} configure'.format(

--- a/datadotworld/config.py
+++ b/datadotworld/config.py
@@ -107,11 +107,12 @@ class FileConfig(DefaultConfig):
     @property
     def config_parser(self):
         if self._config_parser is None:
-            self.configure_config_parser()
+            self._config_parser = self.get_config_parser()
 
         return self._config_parser
 
-    def configure_config_parser(self):
+    def get_config_parser(self):
+        # FIXME this should probably be a pure function
         if not path.isdir(path.dirname(self._config_file_path)):
             os.makedirs(path.dirname(self._config_file_path))
 
@@ -120,14 +121,18 @@ class FileConfig(DefaultConfig):
 
         if path.isfile(self._config_file_path):
             self._config_parser.read_file(open(self._config_file_path))
+
             if self.__migrate_invalid_defaults(self._config_parser) > 0:
                 self.save()
+
         elif path.isfile(self.legacy_file_path):
             self._config_parser = self.__migrate_config(self.legacy_file_path)
             self.save()
 
         if not path.isdir(path.dirname(self.cache_dir)):
             os.makedirs(path.dirname(self.cache_dir))
+
+        return self._config_parser
 
     @property
     def auth_token(self):
@@ -237,7 +242,6 @@ class ChainedConfig(DefaultConfig):
         """
         for i in seq:
             obj = supplier_func(i)
-            print('{} => {}'.format(i, obj))
             if obj is not None:
                 return obj
 

--- a/datadotworld/config.py
+++ b/datadotworld/config.py
@@ -45,7 +45,7 @@ class DefaultConfig(object):
     def __init__(self):
         self._auth_token = None
         self._tmp_dir = path.expanduser(tempfile.gettempdir())
-        self._cache_dir = path.expanduser('~/.dw/cache')
+        self._cache_dir = None
 
     @property
     def auth_token(self):
@@ -103,6 +103,8 @@ class FileConfig(DefaultConfig):
         self._section = (profile
                          if profile.lower() != configparser.DEFAULTSECT.lower()
                          else configparser.DEFAULTSECT)
+
+        self._cache_dir = path.expanduser('~/.dw/cache')
 
     @property
     def config_parser(self):

--- a/datadotworld/config.py
+++ b/datadotworld/config.py
@@ -237,6 +237,7 @@ class ChainedConfig(DefaultConfig):
         """
         for i in seq:
             obj = supplier_func(i)
+            print('{} => {}'.format(i, obj))
             if obj is not None:
                 return obj
 

--- a/tests/datadotworld/test_config.py
+++ b/tests/datadotworld/test_config.py
@@ -60,7 +60,7 @@ class TestDefaultConfig:
 
     def test_cache_dir(self):
         assert_that(DefaultConfig().cache_dir,
-                    equal_to(path.expanduser('~/.dw/cache')))
+                    equal_to(None))
 
     def test_tmp_dir(self):
         assert_that(DefaultConfig().tmp_dir,
@@ -75,7 +75,7 @@ class TestInlineConfig:
     def test_cache_dir(self):
         config = InlineConfig('inline_token')
         assert_that(config.cache_dir,
-                    equal_to(path.expanduser('~/.dw/cache')))
+                    equal_to(None))
 
     def test_tmp_dir(self):
         config = InlineConfig('inline_token')
@@ -197,6 +197,11 @@ class TestFileConfig:
 
         with pytest.raises(PermissionError):
             config.get_config_parser()
+
+    def test_cache_dir(self):
+        config = FileConfig()
+        assert_that(config.cache_dir,
+                    equal_to(path.expanduser('~/.dw/cache')))
 
 
 class TestChainedConfig:

--- a/tests/datadotworld/test_config.py
+++ b/tests/datadotworld/test_config.py
@@ -196,7 +196,7 @@ class TestFileConfig:
         config = FileConfig(config_file_path='/foo/bar/baz/')
 
         with pytest.raises(PermissionError):
-            config.configure_config_parser()
+            config.get_config_parser()
 
 
 class TestChainedConfig:

--- a/tests/datadotworld/test_config.py
+++ b/tests/datadotworld/test_config.py
@@ -191,6 +191,13 @@ class TestFileConfig:
         config_reloaded = FileConfig(config_file_path=config_file_path)
         assert_that(config_reloaded.auth_token, equal_to('newtoken'))
 
+    @pytest.mark.usefixtures('config_directory', 'default_config_file')
+    def test_invalid_config_file_path(self, config_file_path):
+        config = FileConfig(config_file_path='/foo/bar/baz/')
+
+        with pytest.raises(PermissionError):
+            config.configure_config_parser()
+
 
 class TestChainedConfig:
     @pytest.fixture()


### PR DESCRIPTION
**Problem.** The call `dw.load_dataset('...', auto_update=True)` won't run on AWS Lambda with the error:

```
[Errno 30] Read-only file system: '/home/sbx_user1051'
```
The crash happens at `datadotworld.config:FileConfig.__init__`, at the line

```python
os.makedirs(path.dirname(self._config_file_path))
```

The reason of this is that the single directory you can write at in AWS Lambda is `/tmp`. Note the environment variables (`DW_AUTH_TOKEN`, `DW_CACHE_DIR`, `DW_TMP_DIR`) were correctly (as can be seen from the following) configured in Lambda panel, and the two latter ones were pointed to `/tmp/dw_cache/` and `/tmp/dw_tmp/` directories, respectively.

Thus, we expect DW to look into environment variables but it still reaches out to the readonly filesystem. The mechanism of this is located at `datadotworld._get_instance()` function.

**Manual solution** is straightforward: we can use `dw.DataDotWorld(config=dw.EnvConfig()).load_dataset(...)` - that works perfectly.

However, `ChainConfig` seems to be built specifically for use cases like this, with the intention of automatically guessing what config to use without unwanted side effects from other configs.

**Automatic Solution, step 1: FileConfig operations.** This pull request moves over the FS-dependent code into a function of `FileConfig` and wraps `self._config_parser` into a lazy property. A test (however clumsy) is written. Proves to work with AWS Lambda, but not to the full extent. It crashes:

```
...
  File "/var/task/datadotworld/__init__.py", line 101, in load_dataset
    auto_update=auto_update)
  File "/var/task/datadotworld/datadotworld.py", line 152, in load_dataset
    dataset_key, cache_dir)
  File "/var/task/datadotworld/client/api.py", line 494, in download_datapackage
    shutil.move(unzipped_dir, dest_dir)
   ...
  File "/var/lang/lib/python3.7/os.py", line 221, in makedirs
    mkdir(name, mode)
```

Why?

**Automatic Solution, step 2: Cache dir.* Research shows that `ChainConfig` is looping through all configs in its chain and fetching the first one which returns a non-`None` value for the field it is in need right now. That's what happens for `cache_dir`, which is hardcoded in `DefaultConfig` to be `path.expanduser('~/.dw/cache')`. Since `InlineConfig` is the first element in the chain and directly derives this field from `DefaultConfig`, - `ChainConfig` never even asks `EnvConfig` for this field. Using the default config chain mechanism, we can never override `cache_dir`.

I am removing this default declaration from `DefaultConfig` and moving it over to `FileConfig` where it does not bother me, but I realize a) this might be a backwards incompatible change and b) there is no actual reason to put the default value specifically into `FileConfig`. The more correct mechanism would be probably to poll all configs in the chain and, only if none of them returned a valid value, get a default value out of the sleeve.

Any other comments?