### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -283,12 +283,12 @@ Additional API Features
 For a complete list of available API operations, see
 `official documentation <https://docs.data.world/documentation/api/>`_.
 
-Python wrappers are implemented by the ``ApiClient`` class. To obtain an instance, simply call ``api_client``.
+Python wrappers are implemented by the ``ApiClient`` class. To obtain an instance, simply call ``api_client()``.
 For example:
 
 .. code-block:: python
 
-    client = dw.api_client
+    client = dw.api_client()
 
 The client currently implements the following functions:
 
@@ -338,7 +338,7 @@ For example:
 
 .. code-block:: python
 
-    >>> client = dw.api_client
+    >>> client = dw.api_client()
     >>> client.add_files_via_url('username/test-dataset', files={'sample.xls': {'url':'http://www.sample.com/sample.xls', 'description': 'sample doc', 'labels': ['raw data']}})
 
 Append records to stream
@@ -350,7 +350,7 @@ For example:
 
 .. code-block:: python
 
-    >>> client = dw.api_client
+    >>> client = dw.api_client()
     >>> client.append_records('username/test-dataset','streamId', {'data': 'data'})
 
 Contents of a stream will appear as part of the respective dataset as a .jsonl file.


### PR DESCRIPTION
An ApiClient instance is done by calling the api_client() function within the datadotworld module:
import datadotworld as dw
client = dw.api_client()

currently the README treats api_client as though it's a property.  when we run
import datadotworld as dw
client = dw.api_client
client.get_user_data()
we receive the response:
AttributeError: 'function' object has no attribute 'get_user_data'