### PR TITLE
Update references to new main branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,8 +38,8 @@ $ python setup.py test
 ### Create a Feature Branch
 
 ```sh
-$ git checkout master
-$ git pull upstream master
+$ git checkout main
+$ git pull upstream main
 $ git checkout -b my-feature-branch
 ```
 ### Running Swagger-codegen
@@ -66,7 +66,7 @@ Make sure to fix any errors that appear if any.
 
 ### Write Documentation
 
-Document any external behavior in the [README](https://github.com/datadotworld/data.world-py/blob/master/README.rst).
+Document any external behavior in the [README](https://github.com/datadotworld/data.world-py/blob/main/README.rst).
 
 ### Commit Changes
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ test-report:
 update_swagger_codegen:
 	mvn dependency:get -Dartifact=io.swagger:swagger-codegen-cli:2.2.3:jar -DremoteRepositories=central::default::https://repo.maven.apache.org/maven2
 	pushd datadotworld/client; \
-	curl https://raw.githubusercontent.com/datadotworld/dwapi-spec/master/src/main/resources/world/data/api/swagger.json -o swagger-dwapi-def.json; \
+	curl https://raw.githubusercontent.com/datadotworld/dwapi-spec/main/src/main/resources/world/data/api/swagger.json -o swagger-dwapi-def.json; \
 	java -jar ~/.m2/repository/io/swagger/swagger-codegen-cli/2.2.3/swagger-codegen-cli-2.2.3.jar generate -l python --git-repo-id=data.world-py --git-user-id=datadotworld \
 		--http-user-agent="data.world-py" --invoker-package=client \
 		-i swagger-dwapi-def.json -c swagger-codegen-config.json --release-note=""; \


### PR DESCRIPTION
Update README instructions to reference new `main` branch. Also update the `dwapi-spec` installation URL, now that its branch has been renamed to `main` as well.