### PR TITLE
Update DOCTYPE format to fix GitHub pages build

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <!-- Required meta tags -->


### PR DESCRIPTION
This [Stack Overflow comment](https://stackoverflow.com/a/48037023) indicates that _maybe_ changing the `doctype` to `DOCTYPE` could resolve the issue—although this was all from 2017.

