### PR TITLE
[PAP-174] python SDK uses an older version of click library

### DIFF
--- a/datadotworld/__init__.py
+++ b/datadotworld/__init__.py
@@ -35,7 +35,7 @@ from datadotworld.config import (
 )
 from datadotworld.datadotworld import DataDotWorld, UriParam  # noqa: F401
 
-__version__ = '1.8.1'
+__version__ = '1.8.2'
 
 # Convenience top-level functions
 

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     ],
     install_requires=[
         'certifi>=2017.04.17',
-        'click>=6.0,<7.0a',
+        'click>=8.0,<9.0a',
         'configparser>=3.5.0,<4.0a',
         'datapackage>=1.6.2,<2.0a',
         'tableschema>=1.5.2,<2.0a',


### PR DESCRIPTION
Ticket : https://dataworld.atlassian.net/browse/PAP-174