### PR TITLE
PAPPY-277: Remove outdated file functionality (new PR)

### DIFF
--- a/datadotworld/client/api.py
+++ b/datadotworld/client/api.py
@@ -944,9 +944,6 @@ class RestApiClient(object):
             'CC-BY-SA', 'ODC-ODbL', 'CC BY-NC', 'CC BY-NC-SA', 'Other'}
         :param visibility: Project visibility
         :type visibility: {'OPEN', 'PRIVATE'}
-        :param files: File name as dict, source URLs, description and labels() as properties
-        :type files: dict, optional
-            *Description and labels are optional*
         :param linked_datasets: Initial set of linked datasets.
         :type linked_datasets: list of object, optional
         :returns: project object
@@ -968,12 +965,7 @@ class RestApiClient(object):
                 title=kwargs.get('title'),
                 visibility=kwargs.get('visibility')
             ),
-            lambda name, url, description, labels:
-            _swagger.FileCreateRequest(
-                name=name,
-                source=_swagger.FileSourceCreateRequest(url=url),
-                description=description,
-                labels=labels),
+            lambda x: x,
             kwargs)
         try:
             project_owner_id, project_id = parse_dataset_key(project_key)

--- a/datadotworld/client/api.py
+++ b/datadotworld/client/api.py
@@ -1516,7 +1516,9 @@ class RestApiClient(object):
 
     @staticmethod
     def __build_dataset_obj(dataset_constructor, file_constructor, args):
-        files = ([file_constructor(
+        dataset = __build_dataset_obj_no_files(dataset_constructor, args)
+
+        dataset.files = ([file_constructor(
             name,
             url=file_info.get('url'),
             expand_archive=file_info.get('expand_archive', False),
@@ -1524,22 +1526,6 @@ class RestApiClient(object):
             labels=file_info.get('labels'))
                      for name, file_info in args['files'].items()]
                  if 'files' in args else None)
-
-        dataset = dataset_constructor()
-        if 'title' in args:
-            dataset.title = args['title']
-        if 'description' in args:
-            dataset.description = args['description']
-        if 'summary' in args:
-            dataset.summary = args['summary']
-        if 'tags' in args:
-            dataset.tags = args['tags']
-        if 'license' in args:
-            dataset.license = args.get('license')
-        if 'visibility' in args:
-            dataset.visibility = args['visibility']
-
-        dataset.files = files
 
         return dataset
 
@@ -1563,31 +1549,15 @@ class RestApiClient(object):
 
     @staticmethod
     def __build_project_obj(project_constructor, file_constructor, args):
-        files = ([file_constructor(
+        project = __build_project_obj_no_files(project_constructor, args)
+
+        project.files = ([file_constructor(
             name,
             url=file_info.get('url'),
             description=file_info.get('description'),
             labels=file_info.get('labels'))
                      for name, file_info in args['files'].items()]
                  if 'files' in args else None)
-
-        project = project_constructor()
-        if 'title' in args:
-            project.title = args['title']
-        if 'summary' in args:
-            project.summary = args['summary']
-        if 'tags' in args:
-            project.tags = args['tags']
-        if 'license' in args:
-            project.license = args['license']
-        if 'visibility' in args:
-            project.visibility = args['visibility']
-        if 'objective' in args:
-            project.objective = args['objective']
-        if 'linked_datasets' in args:
-            project.linked_datasets = args['linked_datasets']
-
-        project.files = files
 
         return project
 

--- a/datadotworld/client/api.py
+++ b/datadotworld/client/api.py
@@ -1539,8 +1539,7 @@ class RestApiClient(object):
         if 'visibility' in args:
             dataset.visibility = args['visibility']
 
-        if files:
-            dataset.files = files
+        dataset.files = files
 
         return dataset
 
@@ -1588,8 +1587,7 @@ class RestApiClient(object):
         if 'linked_datasets' in args:
             project.linked_datasets = args['linked_datasets']
 
-        if files:
-            project.files = files
+        project.files = files
 
         return project
 

--- a/datadotworld/client/api.py
+++ b/datadotworld/client/api.py
@@ -1516,7 +1516,7 @@ class RestApiClient(object):
 
     @staticmethod
     def __build_dataset_obj(dataset_constructor, file_constructor, args):
-        dataset = dataset_constructor.__build_dataset_obj_no_files(
+        dataset = RestApiClient.__build_dataset_obj_no_files(
             dataset_constructor, args)
 
         dataset.files = ([file_constructor(
@@ -1550,7 +1550,7 @@ class RestApiClient(object):
 
     @staticmethod
     def __build_project_obj(project_constructor, file_constructor, args):
-        project = project_constructor.__build_project_obj_no_files(
+        project = RestApiClient.__build_project_obj_no_files(
             project_constructor, args)
 
         project.files = ([file_constructor(

--- a/datadotworld/client/api.py
+++ b/datadotworld/client/api.py
@@ -26,7 +26,6 @@ import os
 import shutil
 import uuid
 import zipfile
-from multipledispatch import dispatch
 from os import path
 
 import requests
@@ -36,8 +35,8 @@ from datadotworld.client import _swagger
 from datadotworld.client.content_negotiating_api_client import (
     ContentNegotiatingApiClient
 )
-from datadotworld.util import parse_dataset_key, _user_agent
 from datadotworld.hosts import API_HOST, DOWNLOAD_HOST
+from datadotworld.util import parse_dataset_key, _user_agent
 
 
 class RestApiClient(object):
@@ -187,7 +186,7 @@ class RestApiClient(object):
         ...    'username/test-dataset',
         ...    tags=['demo', 'datadotworld'])  # doctest: +SKIP
         """
-        request = self.__build_dataset_obj(
+        request = self.__build_dataset_obj_no_files(
             lambda: _swagger.DatasetPatchRequest(),
             kwargs)
         owner_id, dataset_id = parse_dataset_key(dataset_key)
@@ -225,7 +224,7 @@ class RestApiClient(object):
         ...    visibility='PRIVATE', license='Public Domain',
         ...    description='A better description')  # doctest: +SKIP
         """
-        request = self.__build_dataset_obj(
+        request = self.__build_dataset_obj_no_files(
             lambda: _swagger.DatasetPutRequest(
                 title=kwargs.get('title'),
                 visibility=kwargs.get('visibility')
@@ -908,7 +907,7 @@ class RestApiClient(object):
         ...    'username/test-project',
         ...    tags=['demo', 'datadotworld'])  # doctest: +SKIP
         """
-        request = self.__build_project_obj(
+        request = self.__build_project_obj_no_files(
             lambda: _swagger.ProjectPatchRequest(),
             kwargs)
         owner_id, project_id = parse_dataset_key(project_key)
@@ -958,7 +957,7 @@ class RestApiClient(object):
         ...    objective='A better objective',
         ...    title='Replace project')  # doctest: +SKIP
         """
-        request = self.__build_project_obj(
+        request = self.__build_project_obj_no_files(
             lambda: _swagger.ProjectCreateRequest(
                 title=kwargs.get('title'),
                 visibility=kwargs.get('visibility')
@@ -1516,7 +1515,6 @@ class RestApiClient(object):
             raise RestApiError(cause=e)
 
     @staticmethod
-    @dispatch(object, object, object)
     def __build_dataset_obj(dataset_constructor, file_constructor, args):
         files = ([file_constructor(
             name,
@@ -1547,8 +1545,7 @@ class RestApiClient(object):
         return dataset
 
     @staticmethod
-    @dispatch(object, object)
-    def __build_dataset_obj(dataset_constructor, args):
+    def __build_dataset_obj_no_files(dataset_constructor, args):
         dataset = dataset_constructor()
         if 'title' in args:
             dataset.title = args['title']
@@ -1566,7 +1563,6 @@ class RestApiClient(object):
         return dataset
 
     @staticmethod
-    @dispatch(object, object, object)
     def __build_project_obj(project_constructor, file_constructor, args):
         files = ([file_constructor(
             name,
@@ -1598,8 +1594,7 @@ class RestApiClient(object):
         return project
 
     @staticmethod
-    @dispatch(object, object)
-    def __build_project_obj(project_constructor, args):
+    def __build_project_obj_no_files(project_constructor, args):
         project = project_constructor()
         if 'title' in args:
             project.title = args['title']

--- a/datadotworld/client/api.py
+++ b/datadotworld/client/api.py
@@ -1516,7 +1516,7 @@ class RestApiClient(object):
 
     @staticmethod
     def __build_dataset_obj(dataset_constructor, file_constructor, args):
-        dataset = __build_dataset_obj_no_files(dataset_constructor, args)
+        dataset = dataset_constructor.__build_dataset_obj_no_files(dataset_constructor, args)
 
         dataset.files = ([file_constructor(
             name,
@@ -1549,7 +1549,7 @@ class RestApiClient(object):
 
     @staticmethod
     def __build_project_obj(project_constructor, file_constructor, args):
-        project = __build_project_obj_no_files(project_constructor, args)
+        project = project_constructor.__build_project_obj_no_files(project_constructor, args)
 
         project.files = ([file_constructor(
             name,

--- a/datadotworld/client/api.py
+++ b/datadotworld/client/api.py
@@ -188,7 +188,6 @@ class RestApiClient(object):
         """
         request = self.__build_dataset_obj(
             lambda: _swagger.DatasetPatchRequest(),
-            lambda x: x,
             kwargs)
         owner_id, dataset_id = parse_dataset_key(dataset_key)
         try:
@@ -230,7 +229,6 @@ class RestApiClient(object):
                 title=kwargs.get('title'),
                 visibility=kwargs.get('visibility')
             ),
-            lambda x: x,
             kwargs)
 
         owner_id, dataset_id = parse_dataset_key(dataset_key)
@@ -911,7 +909,6 @@ class RestApiClient(object):
         """
         request = self.__build_project_obj(
             lambda: _swagger.ProjectPatchRequest(),
-            lambda x: x,
             kwargs)
         owner_id, project_id = parse_dataset_key(project_key)
         try:
@@ -965,7 +962,6 @@ class RestApiClient(object):
                 title=kwargs.get('title'),
                 visibility=kwargs.get('visibility')
             ),
-            lambda x: x,
             kwargs)
         try:
             project_owner_id, project_id = parse_dataset_key(project_key)
@@ -1549,6 +1545,24 @@ class RestApiClient(object):
         return dataset
 
     @staticmethod
+    def __build_dataset_obj(dataset_constructor, args):
+        dataset = dataset_constructor()
+        if 'title' in args:
+            dataset.title = args['title']
+        if 'description' in args:
+            dataset.description = args['description']
+        if 'summary' in args:
+            dataset.summary = args['summary']
+        if 'tags' in args:
+            dataset.tags = args['tags']
+        if 'license' in args:
+            dataset.license = args.get('license')
+        if 'visibility' in args:
+            dataset.visibility = args['visibility']
+
+        return dataset
+
+    @staticmethod
     def __build_project_obj(project_constructor, file_constructor, args):
         files = ([file_constructor(
             name,
@@ -1576,6 +1590,26 @@ class RestApiClient(object):
 
         if files:
             project.files = files
+
+        return project
+
+    @staticmethod
+    def __build_project_obj(project_constructor, args):
+        project = project_constructor()
+        if 'title' in args:
+            project.title = args['title']
+        if 'summary' in args:
+            project.summary = args['summary']
+        if 'tags' in args:
+            project.tags = args['tags']
+        if 'license' in args:
+            project.license = args['license']
+        if 'visibility' in args:
+            project.visibility = args['visibility']
+        if 'objective' in args:
+            project.objective = args['objective']
+        if 'linked_datasets' in args:
+            project.linked_datasets = args['linked_datasets']
 
         return project
 

--- a/datadotworld/client/api.py
+++ b/datadotworld/client/api.py
@@ -26,6 +26,7 @@ import os
 import shutil
 import uuid
 import zipfile
+from multipledispatch import dispatch
 from os import path
 
 import requests
@@ -1515,6 +1516,7 @@ class RestApiClient(object):
             raise RestApiError(cause=e)
 
     @staticmethod
+    @dispatch(object, object, object)
     def __build_dataset_obj(dataset_constructor, file_constructor, args):
         files = ([file_constructor(
             name,
@@ -1545,6 +1547,7 @@ class RestApiClient(object):
         return dataset
 
     @staticmethod
+    @dispatch(object, object)
     def __build_dataset_obj(dataset_constructor, args):
         dataset = dataset_constructor()
         if 'title' in args:
@@ -1563,6 +1566,7 @@ class RestApiClient(object):
         return dataset
 
     @staticmethod
+    @dispatch(object, object, object)
     def __build_project_obj(project_constructor, file_constructor, args):
         files = ([file_constructor(
             name,
@@ -1594,6 +1598,7 @@ class RestApiClient(object):
         return project
 
     @staticmethod
+    @dispatch(object, object)
     def __build_project_obj(project_constructor, args):
         project = project_constructor()
         if 'title' in args:

--- a/datadotworld/client/api.py
+++ b/datadotworld/client/api.py
@@ -1516,7 +1516,8 @@ class RestApiClient(object):
 
     @staticmethod
     def __build_dataset_obj(dataset_constructor, file_constructor, args):
-        dataset = dataset_constructor.__build_dataset_obj_no_files(dataset_constructor, args)
+        dataset = dataset_constructor.__build_dataset_obj_no_files(
+            dataset_constructor, args)
 
         dataset.files = ([file_constructor(
             name,
@@ -1549,7 +1550,8 @@ class RestApiClient(object):
 
     @staticmethod
     def __build_project_obj(project_constructor, file_constructor, args):
-        project = project_constructor.__build_project_obj_no_files(project_constructor, args)
+        project = project_constructor.__build_project_obj_no_files(
+            project_constructor, args)
 
         project.files = ([file_constructor(
             name,

--- a/datadotworld/client/swagger-dwapi-def.json
+++ b/datadotworld/client/swagger-dwapi-def.json
@@ -856,9 +856,10 @@
           "type": "string"
         },
         "visibility": {
-          "description": "Dataset visibility. `OPEN` if the dataset can be seen by any member of data.world. `PRIVATE` if the dataset can be seen by its owner and authorized collaborators.",
+          "description": "Dataset visibility. `OPEN` if the dataset can be seen by any member of data.world. `PRIVATE` if the dataset can be seen by its owner and authorized collaborators. `DISCOVERABLE` if the dataset can be seen by any member of data.world, but only files marked `sample` or `preview` are visible",
           "enum": [
             "OPEN",
+            "DISCOVERABLE",
             "PRIVATE"
           ],
           "type": "string"
@@ -974,9 +975,10 @@
           "type": "string"
         },
         "visibility": {
-          "description": "Dataset visibility. `OPEN` if the dataset can be seen by any member of data.world. `PRIVATE` if the dataset can be seen by its owner and authorized collaborators.",
+          "description": "Dataset visibility. `OPEN` if the dataset can be seen by any member of data.world. `PRIVATE` if the dataset can be seen by its owner and authorized collaborators. `DISCOVERABLE` if the dataset can be seen by any member of data.world, but only files marked `sample` or `preview` are visible",
           "enum": [
             "OPEN",
+            "DISCOVERABLE",
             "PRIVATE"
           ],
           "type": "string"
@@ -1028,9 +1030,10 @@
           "type": "string"
         },
         "visibility": {
-          "description": "Dataset visibility. `OPEN` if the dataset can be seen by any member of data.world. `PRIVATE` if the dataset can be seen by its owner and authorized collaborators.",
+          "description": "Dataset visibility. `OPEN` if the dataset can be seen by any member of data.world. `PRIVATE` if the dataset can be seen by its owner and authorized collaborators. `DISCOVERABLE` if the dataset can be seen by any member of data.world, but only files marked `sample` or `preview` are visible",
           "enum": [
             "OPEN",
+            "DISCOVERABLE",
             "PRIVATE"
           ],
           "type": "string"

--- a/datadotworld/client/swagger-dwapi-def.json
+++ b/datadotworld/client/swagger-dwapi-def.json
@@ -812,84 +812,60 @@
         }
       }
     },
-    "DatasetCreateRequest": {
-      "properties": {
-        "description": {
-          "description": "Short dataset description.",
-          "maxLength": 120,
-          "minLength": 0,
-          "type": "string"
+    "DatasetCreateRequest" : {
+      "type" : "object",
+      "required" : [ "title", "visibility" ],
+      "properties" : {
+        "assetStatusIri" : {
+          "type" : "string"
         },
-        "files": {
-          "description": "Initial set of files. At dataset creation time, file uploads are not supported. However, this property can be used to add files via URL.",
-          "items": {
-            "$ref": "#/definitions/FileCreateRequest"
-          },
-          "type": "array",
-          "uniqueItems": false
+        "autoSyncInterval" : {
+          "type" : "string",
+          "description" : "Interval in which files should be synced",
+          "enum" : [ "NEVER", "HOURLY", "DAILY", "WEEKLY" ]
         },
-        "license": {
-          "description": "Dataset license. Find additional info for allowed values [here](https://data.world/license-help).",
-          "enum": [
-            "Public Domain",
-            "PDDL",
-            "CC-0",
-            "CC-BY",
-            "CDLA-Permissive-1.0",
-            "ODC-BY",
-            "CC-BY-SA",
-            "CDLA-Sharing-1.0",
-            "ODC-ODbL",
-            "CC BY-NC",
-            "CC BY-ND",
-            "CC BY-NC-ND",
-            "CC BY-NC-SA",
-            "Other"
-          ],
-          "type": "string"
+        "description" : {
+          "type" : "string",
+          "minLength" : 0,
+          "maxLength" : 120
         },
-        "summary": {
-          "description": "Long-form dataset summary (Markdown supported).",
-          "maxLength": 25000,
-          "minLength": 0,
-          "type": "string"
+        "files" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FileCreateRequest"
+          }
         },
-        "tags": {
-          "description": "Dataset tags. Letters numbers and spaces only (max 25 characters).",
-          "items": {
-            "maxLength": 25,
-            "pattern": "^[a-zA-Z0-9\\s]*",
-            "type": "string"
-          },
-          "type": "array",
-          "uniqueItems": true
+        "license" : {
+          "type" : "string",
+          "enum" : [ "Public Domain", "PDDL", "CC-0", "CC-BY", "CDLA-Permissive-1.0", "CC-BY-IGO", "CC-BY 3.0", "CC-BY 3.0 AU", "CC-BY 3.0 IGO", "CC-BY-SA", "CC-BY-SA 3.0", "CDLA-Sharing-1.0", "CC BY-NC", "CC BY-ND", "CC BY-ND 3.0", "CC-BY 3.0 NZ", "CC-BY-NC 3.0", "CC-BY-SA 3.0", "CC BY-NC-ND", "CC-BY-NC-SA 3.0", "CC-BY-SA 3.0 NZ", "CC-BY-NC-SA 3.0 NZ", "CC-BY-NC 3.0 NZ", "CC-BY-NC-ND-NZ-3.0", "CC BY-NC-SA", "CC-BY-NC-SA 3.0", "Italian-ODL", "MIT License", "OGL", "OGL-Canada", "OGL-Nova Scotia", "OGL-UK", "OSODL", "ODC-BY", "ODC-ODbL", "Other" ]
         },
-        "title": {
-          "description": "Dataset name.",
-          "maxLength": 60,
-          "minLength": 1,
-          "type": "string"
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/JsonNode"
+          }
         },
-        "visibility": {
-          "description": "Dataset visibility. `OPEN` if the dataset can be seen by any member of data.world. `PRIVATE` if the dataset can be seen by its owner and authorized collaborators. `DISCOVERABLE` if the dataset can be seen by any member of data.world, but only files marked `sample` or `preview` are visible",
-          "enum": [
-            "OPEN",
-            "DISCOVERABLE",
-            "PRIVATE"
-          ],
-          "type": "string"
+        "summary" : {
+          "type" : "string",
+          "minLength" : 0,
+          "maxLength" : 25000
         },
-        "properties": {
-          "description": "Custom metadata properties. See [/toolkit/custom-metadata](/toolkit/custom-metadata) for more information.",
-          "type": "object"
+        "tags" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "title" : {
+          "type" : "string",
+          "minLength" : 1,
+          "maxLength" : 60
+        },
+        "visibility" : {
+          "type" : "string",
+          "enum" : [ "OPEN", "PRIVATE" ]
         }
-      },
-      "required": [
-        "title",
-        "visibility"
-      ],
-      "title": "Dataset Create Request",
-      "type": "object"
+      }
     },
     "DatasetHydrationDto": {
       "type": "object",
@@ -951,159 +927,93 @@
         "owner"
       ]
     },
-    "DatasetPatchRequest": {
-      "properties": {
-        "description": {
-          "description": "Short dataset description.",
-          "maxLength": 120,
-          "minLength": 0,
-          "type": "string"
+    "DatasetPatchRequest" : {
+      "type" : "object",
+      "properties" : {
+        "assetStatusIri" : {
+          "type" : "string"
         },
-        "files": {
-          "description": "Updated set of files. At dataset update time, file uploads are not supported. However, this property can be used to add files from URL or update metadata related to existing files.",
-          "items": {
-            "$ref": "#/definitions/FileCreateOrUpdateRequest"
-          },
-          "type": "array",
-          "uniqueItems": false
+        "autoSyncInterval" : {
+          "type" : "string",
+          "description" : "Interval in which files should be synced",
+          "enum" : [ "NEVER", "HOURLY", "DAILY", "WEEKLY" ]
         },
-        "license": {
-          "description": "Dataset license. Find additional info for allowed values [here](https://data.world/license-help).",
-          "enum": [
-            "Public Domain",
-            "PDDL",
-            "CC-0",
-            "CC-BY",
-            "CDLA-Permissive-1.0",
-            "ODC-BY",
-            "CC-BY-SA",
-            "CDLA-Sharing-1.0",
-            "ODC-ODbL",
-            "CC BY-NC",
-            "CC BY-ND",
-            "CC BY-NC-ND",
-            "CC BY-NC-SA",
-            "Other"
-          ],
-          "type": "string"
+        "description" : {
+          "type" : "string"
         },
-        "summary": {
-          "description": "Long-form dataset summary (Markdown supported).",
-          "maxLength": 25000,
-          "minLength": 0,
-          "type": "string"
+        "license" : {
+          "type" : "string",
+          "enum" : [ "Public Domain", "PDDL", "CC-0", "CC-BY", "CDLA-Permissive-1.0", "CC-BY-IGO", "CC-BY 3.0", "CC-BY 3.0 AU", "CC-BY 3.0 IGO", "CC-BY-SA", "CC-BY-SA 3.0", "CDLA-Sharing-1.0", "CC BY-NC", "CC BY-ND", "CC BY-ND 3.0", "CC-BY 3.0 NZ", "CC-BY-NC 3.0", "CC-BY-SA 3.0", "CC BY-NC-ND", "CC-BY-NC-SA 3.0", "CC-BY-SA 3.0 NZ", "CC-BY-NC-SA 3.0 NZ", "CC-BY-NC 3.0 NZ", "CC-BY-NC-ND-NZ-3.0", "CC BY-NC-SA", "CC-BY-NC-SA 3.0", "Italian-ODL", "MIT License", "OGL", "OGL-Canada", "OGL-Nova Scotia", "OGL-UK", "OSODL", "ODC-BY", "ODC-ODbL", "Other" ]
         },
-        "tags": {
-          "description": "Dataset tags. Letters numbers and spaces only (max 25 characters).",
-          "items": {
-            "maxLength": 25,
-            "pattern": "^[a-zA-Z0-9\\s]*",
-            "type": "string"
-          },
-          "type": "array",
-          "uniqueItems": true
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/JsonNode"
+          }
         },
-        "title": {
-          "description": "Dataset name.",
-          "maxLength": 60,
-          "minLength": 0,
-          "type": "string"
+        "summary" : {
+          "type" : "string"
         },
-        "visibility": {
-          "description": "Dataset visibility. `OPEN` if the dataset can be seen by any member of data.world. `PRIVATE` if the dataset can be seen by its owner and authorized collaborators. `DISCOVERABLE` if the dataset can be seen by any member of data.world, but only files marked `sample` or `preview` are visible",
-          "enum": [
-            "OPEN",
-            "DISCOVERABLE",
-            "PRIVATE"
-          ],
-          "type": "string"
+        "tags" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
         },
-        "properties": {
-          "description": "Custom metadata properties. See [/toolkit/custom-metadata](/toolkit/custom-metadata) for more information.",
-          "type": "object"
+        "title" : {
+          "type" : "string",
+          "minLength" : 1,
+          "maxLength" : 60
+        },
+        "visibility" : {
+          "type" : "string",
+          "enum" : [ "OPEN", "PRIVATE" ]
         }
-      },
-      "title": "Dataset Update Request",
-      "type": "object"
+      }
     },
-    "DatasetPutRequest": {
-      "properties": {
-        "description": {
-          "description": "Short dataset description.",
-          "maxLength": 120,
-          "minLength": 0,
-          "type": "string"
+    "DatasetPutRequest" : {
+      "type" : "object",
+      "required" : [ "title", "visibility" ],
+      "properties" : {
+        "assetStatusIri" : {
+          "type" : "string"
         },
-        "files": {
-          "description": "Initial set of files. At dataset creation time, file uploads are not supported. However, this property can be used to add files via URL.",
-          "items": {
-            "$ref": "#/definitions/FileCreateRequest"
-          },
-          "type": "array",
-          "uniqueItems": false
+        "description" : {
+          "type" : "string",
+          "minLength" : 0,
+          "maxLength" : 120
         },
-        "license": {
-          "description": "Dataset license. Find additional info for allowed values [here](https://data.world/license-help).",
-          "enum": [
-            "Public Domain",
-            "PDDL",
-            "CC-0",
-            "CC-BY",
-            "CDLA-Permissive-1.0",
-            "ODC-BY",
-            "CC-BY-SA",
-            "CDLA-Sharing-1.0",
-            "ODC-ODbL",
-            "CC BY-NC",
-            "CC BY-ND",
-            "CC BY-NC-ND",
-            "CC BY-NC-SA",
-            "Other"
-          ],
-          "type": "string"
+        "license" : {
+          "type" : "string",
+          "enum" : [ "Public Domain", "PDDL", "CC-0", "CC-BY", "CDLA-Permissive-1.0", "CC-BY-IGO", "CC-BY 3.0", "CC-BY 3.0 AU", "CC-BY 3.0 IGO", "CC-BY-SA", "CC-BY-SA 3.0", "CDLA-Sharing-1.0", "CC BY-NC", "CC BY-ND", "CC BY-ND 3.0", "CC-BY 3.0 NZ", "CC-BY-NC 3.0", "CC-BY-SA 3.0", "CC BY-NC-ND", "CC-BY-NC-SA 3.0", "CC-BY-SA 3.0 NZ", "CC-BY-NC-SA 3.0 NZ", "CC-BY-NC 3.0 NZ", "CC-BY-NC-ND-NZ-3.0", "CC BY-NC-SA", "CC-BY-NC-SA 3.0", "Italian-ODL", "MIT License", "OGL", "OGL-Canada", "OGL-Nova Scotia", "OGL-UK", "OSODL", "ODC-BY", "ODC-ODbL", "Other" ]
         },
-        "summary": {
-          "description": "Long-form dataset summary (Markdown supported).",
-          "maxLength": 25000,
-          "minLength": 0,
-          "type": "string"
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/JsonNode"
+          }
         },
-        "tags": {
-          "description": "Dataset tags. Letters numbers and spaces only (max 25 characters).",
-          "items": {
-            "maxLength": 25,
-            "pattern": "^[a-zA-Z0-9\\s]*",
-            "type": "string"
-          },
-          "type": "array",
-          "uniqueItems": true
+        "summary" : {
+          "type" : "string",
+          "minLength" : 0,
+          "maxLength" : 25000
         },
-        "title": {
-          "description": "Dataset name.",
-          "maxLength": 60,
-          "minLength": 1,
-          "type": "string"
+        "tags" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
         },
-        "visibility": {
-          "description": "Dataset visibility. `OPEN` if the dataset can be seen by any member of data.world. `PRIVATE` if the dataset can be seen by its owner and authorized collaborators. `DISCOVERABLE` if the dataset can be seen by any member of data.world, but only files marked `sample` or `preview` are visible",
-          "enum": [
-            "OPEN",
-            "DISCOVERABLE",
-            "PRIVATE"
-          ],
-          "type": "string"
+        "title" : {
+          "type" : "string",
+          "minLength" : 1,
+          "maxLength" : 60
         },
-        "properties": {
-          "description": "Custom metadata properties. See [/toolkit/custom-metadata](/toolkit/custom-metadata) for more information.",
-          "type": "object"
+        "visibility" : {
+          "type" : "string",
+          "enum" : [ "OPEN", "PRIVATE" ]
         }
-      },
-      "required": [
-        "title",
-        "visibility"
-      ],
-      "title": "Dataset Replace Request",
-      "type": "object"
+      }
     },
     "DatasetSummaryResponse": {
       "properties": {
@@ -2349,241 +2259,147 @@
         "records"
       ]
     },
-    "ProjectCreateRequest": {
-      "properties": {
-        "files": {
-          "description": "Initial set of files. At project creation time, file uploads are not supported. However, this property can be used to add files from URL.",
-          "items": {
-            "$ref": "#/definitions/FileCreateRequest"
-          },
-          "type": "array",
-          "uniqueItems": false
-        },
-        "license": {
-          "description": "Project license. Find additional info for allowed values [here](https://data.world/license-help).",
-          "enum": [
-            "Public Domain",
-            "PDDL",
-            "CC-0",
-            "CC-BY",
-            "CDLA-Permissive-1.0",
-            "ODC-BY",
-            "CC-BY-SA",
-            "CDLA-Sharing-1.0",
-            "ODC-ODbL",
-            "CC BY-NC",
-            "CC BY-ND",
-            "CC BY-NC-ND",
-            "CC BY-NC-SA",
-            "Other"
-          ],
-          "type": "string"
-        },
-        "linkedDatasets": {
-          "description": "Initial set of linked datasets.",
-          "items": {
-            "$ref": "#/definitions/LinkedDatasetCreateOrUpdateRequest"
-          },
-          "type": "array"
-        },
-        "objective": {
-          "description": "Short project objective.",
-          "maxLength": 120,
-          "minLength": 0,
-          "type": "string"
-        },
-        "summary": {
-          "description": "Long-form project summary (Markdown supported).",
-          "maxLength": 25000,
-          "minLength": 0,
-          "type": "string"
-        },
-        "tags": {
-          "description": "Project tags. Letters numbers and spaces only (max 25 characters).",
-          "items": {
-            "maxLength": 25,
-            "pattern": "^[a-zA-Z0-9\\s]*",
-            "type": "string"
-          },
-          "type": "array",
-          "uniqueItems": true
-        },
-        "title": {
-          "description": "Project title.",
-          "maxLength": 60,
-          "minLength": 0,
-          "type": "string"
-        },
-        "visibility": {
-          "description": "Project visibility. `OPEN` if the project can be seen by any member of data.world. `PRIVATE` if the project can be seen by its owner and authorized collaborators.",
-          "enum": [
-            "OPEN",
-            "PRIVATE"
-          ],
-          "type": "string"
-        }
-      },
-      "required": [
-        "title",
-        "visibility"
-      ],
-      "title": "Project Create Request",
-      "type": "object"
-    },
-    "ProjectPatchRequest": {
-      "type": "object",
-      "title": "Project Update Request",
-      "properties": {
-        "files": {
-          "description": "Updated set of files. At project update time, file uploads are not supported. However, this property can be used to add files from URL or update metadata related to existing files. Files included in this request will be added. Previously added files will be preserved without modification.",
-          "type": "array",
-          "uniqueItems": false,
-          "items": {
-            "$ref": "#/definitions/FileCreateOrUpdateRequest"
+    "ProjectCreateRequest" : {
+      "type" : "object",
+      "required" : [ "title", "visibility" ],
+      "properties" : {
+        "files" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FileCreateRequest"
           }
         },
-        "license": {
-          "description": "Project license. Find additional info for allowed values [here](https://data.world/license-help).",
-          "enum": [
-            "Public Domain",
-            "PDDL",
-            "CC-0",
-            "CC-BY",
-            "CDLA-Permissive-1.0",
-            "ODC-BY",
-            "CC-BY-SA",
-            "CDLA-Sharing-1.0",
-            "ODC-ODbL",
-            "CC BY-NC",
-            "CC BY-ND",
-            "CC BY-NC-ND",
-            "CC BY-NC-SA",
-            "Other"
-          ],
-          "type": "string"
+        "license" : {
+          "type" : "string",
+          "enum" : [ "Public Domain", "PDDL", "CC-0", "CC-BY", "CDLA-Permissive-1.0", "CC-BY-IGO", "CC-BY 3.0", "CC-BY 3.0 AU", "CC-BY 3.0 IGO", "CC-BY-SA", "CC-BY-SA 3.0", "CDLA-Sharing-1.0", "CC BY-NC", "CC BY-ND", "CC BY-ND 3.0", "CC-BY 3.0 NZ", "CC-BY-NC 3.0", "CC-BY-SA 3.0", "CC BY-NC-ND", "CC-BY-NC-SA 3.0", "CC-BY-SA 3.0 NZ", "CC-BY-NC-SA 3.0 NZ", "CC-BY-NC 3.0 NZ", "CC-BY-NC-ND-NZ-3.0", "CC BY-NC-SA", "CC-BY-NC-SA 3.0", "Italian-ODL", "MIT License", "OGL", "OGL-Canada", "OGL-Nova Scotia", "OGL-UK", "OSODL", "ODC-BY", "ODC-ODbL", "Other" ]
         },
-        "linkedDatasets": {
-          "type": "array",
-          "description": "Updated set of linked datasets. Datasets linked in this request will be added. Previously linked datasets will be preserved without modification.",
-          "items": {
-            "$ref": "#/definitions/LinkedDatasetCreateOrUpdateRequest"
+        "linkedDatasets" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/LinkedDatasetCreateOrUpdateRequest"
           }
         },
-        "objective": {
-          "description": "Short project objective.",
-          "maxLength": 120,
-          "minLength": 0,
-          "type": "string"
+        "objective" : {
+          "type" : "string",
+          "minLength" : 0,
+          "maxLength" : 120
         },
-        "summary": {
-          "description": "Long-form project summary (Markdown supported).",
-          "maxLength": 25000,
-          "minLength": 0,
-          "type": "string"
-        },
-        "tags": {
-          "description": "Project tags. Letters numbers and spaces only (max 25 characters).",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "maxLength": 25,
-            "pattern": "^[a-zA-Z0-9\\s]*",
-            "type": "string"
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/JsonNode"
           }
         },
-        "title": {
-          "description": "Project title.",
-          "maxLength": 60,
-          "minLength": 0,
-          "type": "string"
+        "summary" : {
+          "type" : "string",
+          "minLength" : 0,
+          "maxLength" : 25000
         },
-        "visibility": {
-          "description": "Project visibility. `OPEN` if the project can be seen by any member of data.world. `PRIVATE` if the project can be seen by its owner and authorized collaborators.",
-          "enum": [
-            "OPEN",
-            "PRIVATE"
-          ],
-          "type": "string"
+        "tags" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "title" : {
+          "type" : "string",
+          "minLength" : 1,
+          "maxLength" : 60
+        },
+        "visibility" : {
+          "type" : "string",
+          "enum" : [ "OPEN", "PRIVATE" ]
         }
       }
     },
-    "ProjectPutRequest": {
-      "title": "Project Create or Update Request",
-      "type": "object",
-      "properties": {
-        "files": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/FileCreateRequest"
+    "ProjectPatchRequest" : {
+      "type" : "object",
+      "properties" : {
+        "license" : {
+          "type" : "string",
+          "enum" : [ "Public Domain", "PDDL", "CC-0", "CC-BY", "CDLA-Permissive-1.0", "CC-BY-IGO", "CC-BY 3.0", "CC-BY 3.0 AU", "CC-BY 3.0 IGO", "CC-BY-SA", "CC-BY-SA 3.0", "CDLA-Sharing-1.0", "CC BY-NC", "CC BY-ND", "CC BY-ND 3.0", "CC-BY 3.0 NZ", "CC-BY-NC 3.0", "CC-BY-SA 3.0", "CC BY-NC-ND", "CC-BY-NC-SA 3.0", "CC-BY-SA 3.0 NZ", "CC-BY-NC-SA 3.0 NZ", "CC-BY-NC 3.0 NZ", "CC-BY-NC-ND-NZ-3.0", "CC BY-NC-SA", "CC-BY-NC-SA 3.0", "Italian-ODL", "MIT License", "OGL", "OGL-Canada", "OGL-Nova Scotia", "OGL-UK", "OSODL", "ODC-BY", "ODC-ODbL", "Other" ]
+        },
+        "linkedDatasets" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/LinkedDatasetCreateOrUpdateRequest"
           }
         },
-        "license": {
-          "enum": [
-            "Public Domain",
-            "PDDL",
-            "CC-0",
-            "CC-BY",
-            "CDLA-Permissive-1.0",
-            "ODC-BY",
-            "CC-BY-SA",
-            "CDLA-Sharing-1.0",
-            "ODC-ODbL",
-            "CC BY-NC",
-            "CC BY-ND",
-            "CC BY-NC-ND",
-            "CC BY-NC-SA",
-            "Other"
-          ],
-          "type": "string"
+        "objective" : {
+          "type" : "string"
         },
-        "linkedDatasets": {
-          "description": "Updated set of linked datasets. Datasets linked in this request will be added. Previously linked datasets will be preserved without modification.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/LinkedDatasetCreateOrUpdateRequest"
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/JsonNode"
           }
         },
-        "objective": {
-          "description": "Short project objective.",
-          "maxLength": 120,
-          "minLength": 0,
-          "type": "string"
+        "summary" : {
+          "type" : "string"
         },
-        "summary": {
-          "description": "Long-form project summary (Markdown supported).",
-          "maxLength": 25000,
-          "minLength": 0,
-          "type": "string"
-        },
-        "tags": {
-          "description": "Project tags. Letters numbers and spaces only (max 25 characters).",
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "maxLength": 25,
-            "pattern": "^[a-zA-Z0-9\\s]*",
-            "type": "string"
+        "tags" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
           }
         },
-        "title": {
-          "type": "string",
-          "description": "Project title.",
-          "maxLength": 60,
-          "minLength": 1
+        "title" : {
+          "type" : "string",
+          "minLength" : 1,
+          "maxLength" : 60
         },
-        "visibility": {
-          "type": "string",
-          "description": "Project visibility. `OPEN` if the project can be seen by any member of data.world. `PRIVATE` if the project can be seen by its owner and authorized collaborators.",
-          "enum": [
-            "OPEN",
-            "PRIVATE"
-          ]
+        "visibility" : {
+          "type" : "string",
+          "enum" : [ "OPEN", "PRIVATE" ]
         }
-      },
-      "required": [
-        "title",
-        "visibility"
-      ]
+      }
+    },
+    "ProjectPutRequest" : {
+      "type" : "object",
+      "required" : [ "title", "visibility" ],
+      "properties" : {
+        "license" : {
+          "type" : "string",
+          "enum" : [ "Public Domain", "PDDL", "CC-0", "CC-BY", "CDLA-Permissive-1.0", "CC-BY-IGO", "CC-BY 3.0", "CC-BY 3.0 AU", "CC-BY 3.0 IGO", "CC-BY-SA", "CC-BY-SA 3.0", "CDLA-Sharing-1.0", "CC BY-NC", "CC BY-ND", "CC BY-ND 3.0", "CC-BY 3.0 NZ", "CC-BY-NC 3.0", "CC-BY-SA 3.0", "CC BY-NC-ND", "CC-BY-NC-SA 3.0", "CC-BY-SA 3.0 NZ", "CC-BY-NC-SA 3.0 NZ", "CC-BY-NC 3.0 NZ", "CC-BY-NC-ND-NZ-3.0", "CC BY-NC-SA", "CC-BY-NC-SA 3.0", "Italian-ODL", "MIT License", "OGL", "OGL-Canada", "OGL-Nova Scotia", "OGL-UK", "OSODL", "ODC-BY", "ODC-ODbL", "Other" ]
+        },
+        "linkedDatasets" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/LinkedDatasetCreateOrUpdateRequest"
+          }
+        },
+        "objective" : {
+          "type" : "string",
+          "minLength" : 0,
+          "maxLength" : 120
+        },
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/JsonNode"
+          }
+        },
+        "summary" : {
+          "type" : "string",
+          "minLength" : 0,
+          "maxLength" : 25000
+        },
+        "tags" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string"
+          }
+        },
+        "title" : {
+          "type" : "string",
+          "minLength" : 1,
+          "maxLength" : 60
+        },
+        "visibility" : {
+          "type" : "string",
+          "enum" : [ "OPEN", "PRIVATE" ]
+        }
+      }
     },
     "ProjectSummaryResponse": {
       "properties": {

--- a/datadotworld/client/swagger-dwapi-def.json
+++ b/datadotworld/client/swagger-dwapi-def.json
@@ -812,60 +812,71 @@
         }
       }
     },
-    "DatasetCreateRequest" : {
-      "type" : "object",
-      "required" : [ "title", "visibility" ],
-      "properties" : {
-        "assetStatusIri" : {
-          "type" : "string"
+    "DatasetCreateRequest": {
+      "properties": {
+        "description": {
+          "description": "Short dataset description.",
+          "maxLength": 120,
+          "minLength": 0,
+          "type": "string"
         },
-        "autoSyncInterval" : {
-          "type" : "string",
-          "description" : "Interval in which files should be synced",
-          "enum" : [ "NEVER", "HOURLY", "DAILY", "WEEKLY" ]
+        "files": {
+          "description": "Initial set of files. At dataset creation time, file uploads are not supported. However, this property can be used to add files via URL.",
+          "items": {
+            "$ref": "#/definitions/FileCreateRequest"
+          },
+          "type": "array",
+          "uniqueItems": false
         },
-        "description" : {
-          "type" : "string",
-          "minLength" : 0,
-          "maxLength" : 120
+        "license": {
+          "description": "Dataset license. Find additional info for allowed values [here](https://data.world/license-help).",
+          "enum": [ "Public Domain", "PDDL", "CC-0", "CC-BY", "CDLA-Permissive-1.0", "CC-BY-IGO", "CC-BY 3.0", "CC-BY 3.0 AU", "CC-BY 3.0 IGO", "CC-BY-SA", "CC-BY-SA 3.0", "CDLA-Sharing-1.0", "CC BY-NC", "CC BY-ND", "CC BY-ND 3.0", "CC-BY 3.0 NZ", "CC-BY-NC 3.0", "CC-BY-SA 3.0", "CC BY-NC-ND", "CC-BY-NC-SA 3.0", "CC-BY-SA 3.0 NZ", "CC-BY-NC-SA 3.0 NZ", "CC-BY-NC 3.0 NZ", "CC-BY-NC-ND-NZ-3.0", "CC BY-NC-SA", "CC-BY-NC-SA 3.0", "Italian-ODL", "MIT License", "OGL", "OGL-Canada", "OGL-Nova Scotia", "OGL-UK", "OSODL", "ODC-BY", "ODC-ODbL", "Other" ],
+          "type": "string"
         },
-        "files" : {
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/definitions/FileCreateRequest"
-          }
+        "summary": {
+          "description": "Long-form dataset summary (Markdown supported).",
+          "maxLength": 25000,
+          "minLength": 0,
+          "type": "string"
         },
-        "license" : {
-          "type" : "string",
-          "enum" : [ "Public Domain", "PDDL", "CC-0", "CC-BY", "CDLA-Permissive-1.0", "CC-BY-IGO", "CC-BY 3.0", "CC-BY 3.0 AU", "CC-BY 3.0 IGO", "CC-BY-SA", "CC-BY-SA 3.0", "CDLA-Sharing-1.0", "CC BY-NC", "CC BY-ND", "CC BY-ND 3.0", "CC-BY 3.0 NZ", "CC-BY-NC 3.0", "CC-BY-SA 3.0", "CC BY-NC-ND", "CC-BY-NC-SA 3.0", "CC-BY-SA 3.0 NZ", "CC-BY-NC-SA 3.0 NZ", "CC-BY-NC 3.0 NZ", "CC-BY-NC-ND-NZ-3.0", "CC BY-NC-SA", "CC-BY-NC-SA 3.0", "Italian-ODL", "MIT License", "OGL", "OGL-Canada", "OGL-Nova Scotia", "OGL-UK", "OSODL", "ODC-BY", "ODC-ODbL", "Other" ]
+        "tags": {
+          "description": "Dataset tags. Letters numbers and spaces only (max 25 characters).",
+          "items": {
+            "maxLength": 25,
+            "pattern": "^[a-zA-Z0-9\\s]*",
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
         },
-        "properties" : {
-          "type" : "object",
+        "title": {
+          "description": "Dataset name.",
+          "maxLength": 60,
+          "minLength": 1,
+          "type": "string"
+        },
+        "visibility": {
+          "description": "Dataset visibility. `OPEN` if the dataset can be seen by any member of data.world. `PRIVATE` if the dataset can be seen by its owner and authorized collaborators.",
+          "enum": [
+            "OPEN",
+            "PRIVATE"
+          ],
+          "type": "string"
+        },
+        "properties": {
+          "description": "Custom metadata properties. See [/toolkit/custom-metadata](/toolkit/custom-metadata) for more information.",
+          "type": "object",
           "additionalProperties" : {
             "$ref" : "#/definitions/JsonNode"
           }
-        },
-        "summary" : {
-          "type" : "string",
-          "minLength" : 0,
-          "maxLength" : 25000
-        },
-        "tags" : {
-          "type" : "array",
-          "items" : {
-            "type" : "string"
-          }
-        },
-        "title" : {
-          "type" : "string",
-          "minLength" : 1,
-          "maxLength" : 60
-        },
-        "visibility" : {
-          "type" : "string",
-          "enum" : [ "OPEN", "PRIVATE" ]
         }
-      }
+      },
+      "required": [
+        "title",
+        "visibility"
+      ],
+      "title": "Dataset Create Request",
+      "type": "object"
     },
     "DatasetHydrationDto": {
       "type": "object",
@@ -927,93 +938,117 @@
         "owner"
       ]
     },
-    "DatasetPatchRequest" : {
-      "type" : "object",
-      "properties" : {
-        "assetStatusIri" : {
-          "type" : "string"
+    "DatasetPatchRequest": {
+      "properties": {
+        "description": {
+          "description": "Short dataset description.",
+          "maxLength": 120,
+          "minLength": 0,
+          "type": "string"
         },
-        "autoSyncInterval" : {
-          "type" : "string",
-          "description" : "Interval in which files should be synced",
-          "enum" : [ "NEVER", "HOURLY", "DAILY", "WEEKLY" ]
+        "license": {
+          "description": "Dataset license. Find additional info for allowed values [here](https://data.world/license-help).",
+          "enum": [ "Public Domain", "PDDL", "CC-0", "CC-BY", "CDLA-Permissive-1.0", "CC-BY-IGO", "CC-BY 3.0", "CC-BY 3.0 AU", "CC-BY 3.0 IGO", "CC-BY-SA", "CC-BY-SA 3.0", "CDLA-Sharing-1.0", "CC BY-NC", "CC BY-ND", "CC BY-ND 3.0", "CC-BY 3.0 NZ", "CC-BY-NC 3.0", "CC-BY-SA 3.0", "CC BY-NC-ND", "CC-BY-NC-SA 3.0", "CC-BY-SA 3.0 NZ", "CC-BY-NC-SA 3.0 NZ", "CC-BY-NC 3.0 NZ", "CC-BY-NC-ND-NZ-3.0", "CC BY-NC-SA", "CC-BY-NC-SA 3.0", "Italian-ODL", "MIT License", "OGL", "OGL-Canada", "OGL-Nova Scotia", "OGL-UK", "OSODL", "ODC-BY", "ODC-ODbL", "Other" ],
+          "type": "string"
         },
-        "description" : {
-          "type" : "string"
+        "summary": {
+          "description": "Long-form dataset summary (Markdown supported).",
+          "maxLength": 25000,
+          "minLength": 0,
+          "type": "string"
         },
-        "license" : {
-          "type" : "string",
-          "enum" : [ "Public Domain", "PDDL", "CC-0", "CC-BY", "CDLA-Permissive-1.0", "CC-BY-IGO", "CC-BY 3.0", "CC-BY 3.0 AU", "CC-BY 3.0 IGO", "CC-BY-SA", "CC-BY-SA 3.0", "CDLA-Sharing-1.0", "CC BY-NC", "CC BY-ND", "CC BY-ND 3.0", "CC-BY 3.0 NZ", "CC-BY-NC 3.0", "CC-BY-SA 3.0", "CC BY-NC-ND", "CC-BY-NC-SA 3.0", "CC-BY-SA 3.0 NZ", "CC-BY-NC-SA 3.0 NZ", "CC-BY-NC 3.0 NZ", "CC-BY-NC-ND-NZ-3.0", "CC BY-NC-SA", "CC-BY-NC-SA 3.0", "Italian-ODL", "MIT License", "OGL", "OGL-Canada", "OGL-Nova Scotia", "OGL-UK", "OSODL", "ODC-BY", "ODC-ODbL", "Other" ]
+        "tags": {
+          "description": "Dataset tags. Letters numbers and spaces only (max 25 characters).",
+          "items": {
+            "maxLength": 25,
+            "pattern": "^[a-zA-Z0-9\\s]*",
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
         },
-        "properties" : {
-          "type" : "object",
+        "title": {
+          "description": "Dataset name.",
+          "maxLength": 60,
+          "minLength": 1,
+          "type": "string"
+        },
+        "visibility": {
+          "description": "Dataset visibility. `OPEN` if the dataset can be seen by any member of data.world. `PRIVATE` if the dataset can be seen by its owner and authorized collaborators.",
+          "enum": [
+            "OPEN",
+            "PRIVATE"
+          ],
+          "type": "string"
+        },
+        "properties": {
+          "description": "Custom metadata properties. See [/toolkit/custom-metadata](/toolkit/custom-metadata) for more information.",
+          "type": "object",
           "additionalProperties" : {
             "$ref" : "#/definitions/JsonNode"
           }
-        },
-        "summary" : {
-          "type" : "string"
-        },
-        "tags" : {
-          "type" : "array",
-          "items" : {
-            "type" : "string"
-          }
-        },
-        "title" : {
-          "type" : "string",
-          "minLength" : 1,
-          "maxLength" : 60
-        },
-        "visibility" : {
-          "type" : "string",
-          "enum" : [ "OPEN", "PRIVATE" ]
         }
-      }
+      },
+      "title": "Dataset Update Request",
+      "type": "object"
     },
-    "DatasetPutRequest" : {
-      "type" : "object",
-      "required" : [ "title", "visibility" ],
-      "properties" : {
-        "assetStatusIri" : {
-          "type" : "string"
+    "DatasetPutRequest": {
+      "properties": {
+        "description": {
+          "description": "Short dataset description.",
+          "maxLength": 120,
+          "minLength": 0,
+          "type": "string"
         },
-        "description" : {
-          "type" : "string",
-          "minLength" : 0,
-          "maxLength" : 120
+        "license": {
+          "description": "Dataset license. Find additional info for allowed values [here](https://data.world/license-help).",
+          "enum": [ "Public Domain", "PDDL", "CC-0", "CC-BY", "CDLA-Permissive-1.0", "CC-BY-IGO", "CC-BY 3.0", "CC-BY 3.0 AU", "CC-BY 3.0 IGO", "CC-BY-SA", "CC-BY-SA 3.0", "CDLA-Sharing-1.0", "CC BY-NC", "CC BY-ND", "CC BY-ND 3.0", "CC-BY 3.0 NZ", "CC-BY-NC 3.0", "CC-BY-SA 3.0", "CC BY-NC-ND", "CC-BY-NC-SA 3.0", "CC-BY-SA 3.0 NZ", "CC-BY-NC-SA 3.0 NZ", "CC-BY-NC 3.0 NZ", "CC-BY-NC-ND-NZ-3.0", "CC BY-NC-SA", "CC-BY-NC-SA 3.0", "Italian-ODL", "MIT License", "OGL", "OGL-Canada", "OGL-Nova Scotia", "OGL-UK", "OSODL", "ODC-BY", "ODC-ODbL", "Other" ],
+          "type": "string"
         },
-        "license" : {
-          "type" : "string",
-          "enum" : [ "Public Domain", "PDDL", "CC-0", "CC-BY", "CDLA-Permissive-1.0", "CC-BY-IGO", "CC-BY 3.0", "CC-BY 3.0 AU", "CC-BY 3.0 IGO", "CC-BY-SA", "CC-BY-SA 3.0", "CDLA-Sharing-1.0", "CC BY-NC", "CC BY-ND", "CC BY-ND 3.0", "CC-BY 3.0 NZ", "CC-BY-NC 3.0", "CC-BY-SA 3.0", "CC BY-NC-ND", "CC-BY-NC-SA 3.0", "CC-BY-SA 3.0 NZ", "CC-BY-NC-SA 3.0 NZ", "CC-BY-NC 3.0 NZ", "CC-BY-NC-ND-NZ-3.0", "CC BY-NC-SA", "CC-BY-NC-SA 3.0", "Italian-ODL", "MIT License", "OGL", "OGL-Canada", "OGL-Nova Scotia", "OGL-UK", "OSODL", "ODC-BY", "ODC-ODbL", "Other" ]
+        "summary": {
+          "description": "Long-form dataset summary (Markdown supported).",
+          "maxLength": 25000,
+          "minLength": 0,
+          "type": "string"
         },
-        "properties" : {
-          "type" : "object",
+        "tags": {
+          "description": "Dataset tags. Letters numbers and spaces only (max 25 characters).",
+          "items": {
+            "maxLength": 25,
+            "pattern": "^[a-zA-Z0-9\\s]*",
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "title": {
+          "description": "Dataset name.",
+          "maxLength": 60,
+          "minLength": 1,
+          "type": "string"
+        },
+        "visibility": {
+          "description": "Dataset visibility. `OPEN` if the dataset can be seen by any member of data.world. `PRIVATE` if the dataset can be seen by its owner and authorized collaborators.",
+          "enum": [
+            "OPEN",
+            "PRIVATE"
+          ],
+          "type": "string"
+        },
+        "properties": {
+          "description": "Custom metadata properties. See [/toolkit/custom-metadata](/toolkit/custom-metadata) for more information.",
+          "type": "object",
           "additionalProperties" : {
             "$ref" : "#/definitions/JsonNode"
           }
-        },
-        "summary" : {
-          "type" : "string",
-          "minLength" : 0,
-          "maxLength" : 25000
-        },
-        "tags" : {
-          "type" : "array",
-          "items" : {
-            "type" : "string"
-          }
-        },
-        "title" : {
-          "type" : "string",
-          "minLength" : 1,
-          "maxLength" : 60
-        },
-        "visibility" : {
-          "type" : "string",
-          "enum" : [ "OPEN", "PRIVATE" ]
         }
-      }
+      },
+      "required": [
+        "title",
+        "visibility"
+      ],
+      "title": "Dataset Replace Request",
+      "type": "object"
     },
     "DatasetSummaryResponse": {
       "properties": {
@@ -2259,30 +2294,99 @@
         "records"
       ]
     },
-    "ProjectCreateRequest" : {
-      "type" : "object",
-      "required" : [ "title", "visibility" ],
-      "properties" : {
-        "files" : {
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/definitions/FileCreateRequest"
+    "ProjectCreateRequest": {
+      "properties": {
+        "files": {
+          "description": "Initial set of files. At project creation time, file uploads are not supported. However, this property can be used to add files from URL.",
+          "items": {
+            "$ref": "#/definitions/FileCreateRequest"
+          },
+          "type": "array",
+          "uniqueItems": false
+        },
+        "license": {
+          "description": "Project license. Find additional info for allowed values [here](https://data.world/license-help).",
+          "enum": [ "Public Domain", "PDDL", "CC-0", "CC-BY", "CDLA-Permissive-1.0", "CC-BY-IGO", "CC-BY 3.0", "CC-BY 3.0 AU", "CC-BY 3.0 IGO", "CC-BY-SA", "CC-BY-SA 3.0", "CDLA-Sharing-1.0", "CC BY-NC", "CC BY-ND", "CC BY-ND 3.0", "CC-BY 3.0 NZ", "CC-BY-NC 3.0", "CC-BY-SA 3.0", "CC BY-NC-ND", "CC-BY-NC-SA 3.0", "CC-BY-SA 3.0 NZ", "CC-BY-NC-SA 3.0 NZ", "CC-BY-NC 3.0 NZ", "CC-BY-NC-ND-NZ-3.0", "CC BY-NC-SA", "CC-BY-NC-SA 3.0", "Italian-ODL", "MIT License", "OGL", "OGL-Canada", "OGL-Nova Scotia", "OGL-UK", "OSODL", "ODC-BY", "ODC-ODbL", "Other" ],
+          "type": "string"
+        },
+        "linkedDatasets": {
+          "description": "Initial set of linked datasets.",
+          "items": {
+            "$ref": "#/definitions/LinkedDatasetCreateOrUpdateRequest"
+          },
+          "type": "array"
+        },
+        "objective": {
+          "description": "Short project objective.",
+          "maxLength": 120,
+          "minLength": 0,
+          "type": "string"
+        },
+        "summary": {
+          "description": "Long-form project summary (Markdown supported).",
+          "maxLength": 25000,
+          "minLength": 0,
+          "type": "string"
+        },
+        "tags": {
+          "description": "Project tags. Letters numbers and spaces only (max 25 characters).",
+          "items": {
+            "maxLength": 25,
+            "pattern": "^[a-zA-Z0-9\\s]*",
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "title": {
+          "description": "Project title.",
+          "maxLength": 60,
+          "minLength": 1,
+          "type": "string"
+        },
+        "visibility": {
+          "description": "Project visibility. `OPEN` if the project can be seen by any member of data.world. `PRIVATE` if the project can be seen by its owner and authorized collaborators.",
+          "enum": [
+            "OPEN",
+            "PRIVATE"
+          ],
+          "type": "string"
+        },
+        "properties" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/JsonNode"
+          }
+        }
+      },
+      "required": [
+        "title",
+        "visibility"
+      ],
+      "title": "Project Create Request",
+      "type": "object"
+    },
+    "ProjectPatchRequest": {
+      "type": "object",
+      "title": "Project Update Request",
+      "properties": {
+        "license": {
+          "description": "Project license. Find additional info for allowed values [here](https://data.world/license-help).",
+          "enum": [ "Public Domain", "PDDL", "CC-0", "CC-BY", "CDLA-Permissive-1.0", "CC-BY-IGO", "CC-BY 3.0", "CC-BY 3.0 AU", "CC-BY 3.0 IGO", "CC-BY-SA", "CC-BY-SA 3.0", "CDLA-Sharing-1.0", "CC BY-NC", "CC BY-ND", "CC BY-ND 3.0", "CC-BY 3.0 NZ", "CC-BY-NC 3.0", "CC-BY-SA 3.0", "CC BY-NC-ND", "CC-BY-NC-SA 3.0", "CC-BY-SA 3.0 NZ", "CC-BY-NC-SA 3.0 NZ", "CC-BY-NC 3.0 NZ", "CC-BY-NC-ND-NZ-3.0", "CC BY-NC-SA", "CC-BY-NC-SA 3.0", "Italian-ODL", "MIT License", "OGL", "OGL-Canada", "OGL-Nova Scotia", "OGL-UK", "OSODL", "ODC-BY", "ODC-ODbL", "Other" ],
+          "type": "string"
+        },
+        "linkedDatasets": {
+          "type": "array",
+          "description": "Updated set of linked datasets. Datasets linked in this request will be added. Previously linked datasets will be preserved without modification.",
+          "items": {
+            "$ref": "#/definitions/LinkedDatasetCreateOrUpdateRequest"
           }
         },
-        "license" : {
-          "type" : "string",
-          "enum" : [ "Public Domain", "PDDL", "CC-0", "CC-BY", "CDLA-Permissive-1.0", "CC-BY-IGO", "CC-BY 3.0", "CC-BY 3.0 AU", "CC-BY 3.0 IGO", "CC-BY-SA", "CC-BY-SA 3.0", "CDLA-Sharing-1.0", "CC BY-NC", "CC BY-ND", "CC BY-ND 3.0", "CC-BY 3.0 NZ", "CC-BY-NC 3.0", "CC-BY-SA 3.0", "CC BY-NC-ND", "CC-BY-NC-SA 3.0", "CC-BY-SA 3.0 NZ", "CC-BY-NC-SA 3.0 NZ", "CC-BY-NC 3.0 NZ", "CC-BY-NC-ND-NZ-3.0", "CC BY-NC-SA", "CC-BY-NC-SA 3.0", "Italian-ODL", "MIT License", "OGL", "OGL-Canada", "OGL-Nova Scotia", "OGL-UK", "OSODL", "ODC-BY", "ODC-ODbL", "Other" ]
-        },
-        "linkedDatasets" : {
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/definitions/LinkedDatasetCreateOrUpdateRequest"
-          }
-        },
-        "objective" : {
-          "type" : "string",
-          "minLength" : 0,
-          "maxLength" : 120
+        "objective": {
+          "description": "Short project objective.",
+          "maxLength": 120,
+          "minLength": 0,
+          "type": "string"
         },
         "properties" : {
           "type" : "object",
@@ -2290,43 +2394,58 @@
             "$ref" : "#/definitions/JsonNode"
           }
         },
-        "summary" : {
-          "type" : "string",
-          "minLength" : 0,
-          "maxLength" : 25000
+        "summary": {
+          "description": "Long-form project summary (Markdown supported).",
+          "maxLength": 25000,
+          "minLength": 0,
+          "type": "string"
         },
-        "tags" : {
-          "type" : "array",
-          "items" : {
-            "type" : "string"
+        "tags": {
+          "description": "Project tags. Letters numbers and spaces only (max 25 characters).",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "maxLength": 25,
+            "pattern": "^[a-zA-Z0-9\\s]*",
+            "type": "string"
           }
         },
-        "title" : {
-          "type" : "string",
-          "minLength" : 1,
-          "maxLength" : 60
+        "title": {
+          "description": "Project title.",
+          "maxLength": 60,
+          "minLength": 1,
+          "type": "string"
         },
-        "visibility" : {
-          "type" : "string",
-          "enum" : [ "OPEN", "PRIVATE" ]
+        "visibility": {
+          "description": "Project visibility. `OPEN` if the project can be seen by any member of data.world. `PRIVATE` if the project can be seen by its owner and authorized collaborators.",
+          "enum": [
+            "OPEN",
+            "PRIVATE"
+          ],
+          "type": "string"
         }
       }
     },
-    "ProjectPatchRequest" : {
-      "type" : "object",
-      "properties" : {
-        "license" : {
-          "type" : "string",
-          "enum" : [ "Public Domain", "PDDL", "CC-0", "CC-BY", "CDLA-Permissive-1.0", "CC-BY-IGO", "CC-BY 3.0", "CC-BY 3.0 AU", "CC-BY 3.0 IGO", "CC-BY-SA", "CC-BY-SA 3.0", "CDLA-Sharing-1.0", "CC BY-NC", "CC BY-ND", "CC BY-ND 3.0", "CC-BY 3.0 NZ", "CC-BY-NC 3.0", "CC-BY-SA 3.0", "CC BY-NC-ND", "CC-BY-NC-SA 3.0", "CC-BY-SA 3.0 NZ", "CC-BY-NC-SA 3.0 NZ", "CC-BY-NC 3.0 NZ", "CC-BY-NC-ND-NZ-3.0", "CC BY-NC-SA", "CC-BY-NC-SA 3.0", "Italian-ODL", "MIT License", "OGL", "OGL-Canada", "OGL-Nova Scotia", "OGL-UK", "OSODL", "ODC-BY", "ODC-ODbL", "Other" ]
+    "ProjectPutRequest": {
+      "title": "Project Create or Update Request",
+      "type": "object",
+      "properties": {
+        "license": {
+          "enum": [ "Public Domain", "PDDL", "CC-0", "CC-BY", "CDLA-Permissive-1.0", "CC-BY-IGO", "CC-BY 3.0", "CC-BY 3.0 AU", "CC-BY 3.0 IGO", "CC-BY-SA", "CC-BY-SA 3.0", "CDLA-Sharing-1.0", "CC BY-NC", "CC BY-ND", "CC BY-ND 3.0", "CC-BY 3.0 NZ", "CC-BY-NC 3.0", "CC-BY-SA 3.0", "CC BY-NC-ND", "CC-BY-NC-SA 3.0", "CC-BY-SA 3.0 NZ", "CC-BY-NC-SA 3.0 NZ", "CC-BY-NC 3.0 NZ", "CC-BY-NC-ND-NZ-3.0", "CC BY-NC-SA", "CC-BY-NC-SA 3.0", "Italian-ODL", "MIT License", "OGL", "OGL-Canada", "OGL-Nova Scotia", "OGL-UK", "OSODL", "ODC-BY", "ODC-ODbL", "Other" ],
+          "type": "string"
         },
-        "linkedDatasets" : {
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/definitions/LinkedDatasetCreateOrUpdateRequest"
+        "linkedDatasets": {
+          "description": "Updated set of linked datasets. Datasets linked in this request will be added. Previously linked datasets will be preserved without modification.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LinkedDatasetCreateOrUpdateRequest"
           }
         },
-        "objective" : {
-          "type" : "string"
+        "objective": {
+          "description": "Short project objective.",
+          "maxLength": 120,
+          "minLength": 0,
+          "type": "string"
         },
         "properties" : {
           "type" : "object",
@@ -2334,72 +2453,41 @@
             "$ref" : "#/definitions/JsonNode"
           }
         },
-        "summary" : {
-          "type" : "string"
+        "summary": {
+          "description": "Long-form project summary (Markdown supported).",
+          "maxLength": 25000,
+          "minLength": 0,
+          "type": "string"
         },
-        "tags" : {
-          "type" : "array",
-          "items" : {
-            "type" : "string"
+        "tags": {
+          "description": "Project tags. Letters numbers and spaces only (max 25 characters).",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "maxLength": 25,
+            "pattern": "^[a-zA-Z0-9\\s]*",
+            "type": "string"
           }
         },
-        "title" : {
-          "type" : "string",
-          "minLength" : 1,
-          "maxLength" : 60
+        "title": {
+          "type": "string",
+          "description": "Project title.",
+          "maxLength": 60,
+          "minLength": 1
         },
-        "visibility" : {
-          "type" : "string",
-          "enum" : [ "OPEN", "PRIVATE" ]
+        "visibility": {
+          "type": "string",
+          "description": "Project visibility. `OPEN` if the project can be seen by any member of data.world. `PRIVATE` if the project can be seen by its owner and authorized collaborators.",
+          "enum": [
+            "OPEN",
+            "PRIVATE"
+          ]
         }
-      }
-    },
-    "ProjectPutRequest" : {
-      "type" : "object",
-      "required" : [ "title", "visibility" ],
-      "properties" : {
-        "license" : {
-          "type" : "string",
-          "enum" : [ "Public Domain", "PDDL", "CC-0", "CC-BY", "CDLA-Permissive-1.0", "CC-BY-IGO", "CC-BY 3.0", "CC-BY 3.0 AU", "CC-BY 3.0 IGO", "CC-BY-SA", "CC-BY-SA 3.0", "CDLA-Sharing-1.0", "CC BY-NC", "CC BY-ND", "CC BY-ND 3.0", "CC-BY 3.0 NZ", "CC-BY-NC 3.0", "CC-BY-SA 3.0", "CC BY-NC-ND", "CC-BY-NC-SA 3.0", "CC-BY-SA 3.0 NZ", "CC-BY-NC-SA 3.0 NZ", "CC-BY-NC 3.0 NZ", "CC-BY-NC-ND-NZ-3.0", "CC BY-NC-SA", "CC-BY-NC-SA 3.0", "Italian-ODL", "MIT License", "OGL", "OGL-Canada", "OGL-Nova Scotia", "OGL-UK", "OSODL", "ODC-BY", "ODC-ODbL", "Other" ]
-        },
-        "linkedDatasets" : {
-          "type" : "array",
-          "items" : {
-            "$ref" : "#/definitions/LinkedDatasetCreateOrUpdateRequest"
-          }
-        },
-        "objective" : {
-          "type" : "string",
-          "minLength" : 0,
-          "maxLength" : 120
-        },
-        "properties" : {
-          "type" : "object",
-          "additionalProperties" : {
-            "$ref" : "#/definitions/JsonNode"
-          }
-        },
-        "summary" : {
-          "type" : "string",
-          "minLength" : 0,
-          "maxLength" : 25000
-        },
-        "tags" : {
-          "type" : "array",
-          "items" : {
-            "type" : "string"
-          }
-        },
-        "title" : {
-          "type" : "string",
-          "minLength" : 1,
-          "maxLength" : 60
-        },
-        "visibility" : {
-          "type" : "string",
-          "enum" : [ "OPEN", "PRIVATE" ]
-        }
-      }
+      },
+      "required": [
+        "title",
+        "visibility"
+      ]
     },
     "ProjectSummaryResponse": {
       "properties": {


### PR DESCRIPTION
remove file upload functionality from update_dataset, replace_dataset, update_project, and replace_project; remove unnecessary parameter from __build_dataset_obj and __build_project_obj

Issue: https://dataworld.atlassian.net/browse/PAPPY-277

Re-creating this PR from https://github.com/datadotworld/data.world-py/pull/132 because it was easier than re-reverting the swagger changes