### PR TITLE
[CLOUD-264] CircleCI Context Changes -- added missing env_var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ resources:
     - *base_docker_image
     working_directory: /root/data.world-py
     environment:
+      BASH_ENV: ~/.env
       PRERELEASE_PREFIX: prerelease
       RELEASE_PREFIX: release
 


### PR DESCRIPTION
A continuation of this PR: https://github.com/datadotworld/data.world-py/pull/141